### PR TITLE
SCKAN-77 fix submit form on autosave to work in Firefox and Safari

### DIFF
--- a/frontend/src/components/Forms/FormBase.tsx
+++ b/frontend/src/components/Forms/FormBase.tsx
@@ -27,15 +27,17 @@ export const FormBase = (props: any) => {
     formIsValid,
     children = false,
     widgets,
-    disableSubmitButton,
+    submitButtonProps,
   } = props;
   const [localData, setLocalData] = useState<any>(data);
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const triggerAutoSave = useDebouncedCallback(() => onSave(), EDIT_DEBOUNCE);
+  const [isSubmitButtonDisabled, setIsSubmitButtonDisabled] =
+    useState<boolean>(false);
   const [customSchema, setCustomSchema] = useState<any>(schema);
   const [customUiSchema, setCustomUiSchema] = useState<any>(uiSchema);
 
-  const hiddenButtonRef = useRef<any>(null);
+  const submitButtonRef = useRef<any>(null);
 
   const removeProp = (obj: any, prop: string) => {
     const { [prop]: removedProp, ...newObj } = obj;
@@ -46,9 +48,9 @@ export const FormBase = (props: any) => {
   //as it was mutating the original object at the jsonschema singleton
 
   useEffect(() => {
-    setLocalData(data)
-    setCustomSchema(schema)
-    setCustomUiSchema(uiSchema)
+    setLocalData(data);
+    setCustomSchema(schema);
+    setCustomUiSchema(uiSchema);
     if (uiFields) {
       Object.entries(uiSchema).forEach((p) => {
         if (!p[0].startsWith("ui:") && !uiFields.includes(p[0])) {
@@ -70,8 +72,8 @@ export const FormBase = (props: any) => {
   };
 
   const onSave = () => {
-    if (hiddenButtonRef.current != null) {
-      return hiddenButtonRef.current.click();
+    if (submitButtonRef.current != null) {
+      return submitButtonRef.current.click();
     }
   };
 
@@ -105,9 +107,9 @@ export const FormBase = (props: any) => {
     const formData = { ...event.formData, ...extraData };
     setLocalData(formData);
     if (formIsValid && !formIsValid(formData)) {
-      disableSubmitButton && disableSubmitButton(true);
+      setIsSubmitButtonDisabled(true);
     } else {
-      disableSubmitButton && disableSubmitButton(false);
+      setIsSubmitButtonDisabled(false);
       if (enableAutoSave) {
         return triggerAutoSave();
       }
@@ -131,10 +133,22 @@ export const FormBase = (props: any) => {
           onChange={handleUpdate}
           onSubmit={handleSubmit}
           onError={onError}
-          widgets={widgets}>
-            {children}
-            <Button ref={hiddenButtonRef} type='submit' sx={{display:'none'}}/>
-          </Form>
+          widgets={widgets}
+        >
+          {children}
+
+          <Button
+            ref={submitButtonRef}
+            type="submit"
+            disabled={isSubmitButtonDisabled}
+            sx={{
+              display: (enableAutoSave || !submitButtonProps) && "none",
+            }}
+            {...submitButtonProps}
+          >
+            {submitButtonProps?.label ? submitButtonProps.label : "Submit"}
+          </Button>
+        </Form>
       </Box>
     </>
   );

--- a/frontend/src/components/Forms/NoteForm.tsx
+++ b/frontend/src/components/Forms/NoteForm.tsx
@@ -1,53 +1,28 @@
-import React, {useEffect, useState} from 'react'
-import { Box } from '@mui/material'
-import { FormBase } from './FormBase'
-import { jsonSchemas } from '../../services/JsonSchema'
-import noteService from '../../services/NoteService'
-import Button from "@mui/material/Button";
-import {UiSchema} from "@rjsf/utils";
+import React, { useState } from "react";
+import { FormBase } from "./FormBase";
+import { jsonSchemas } from "../../services/JsonSchema";
+import noteService from "../../services/NoteService";
+import { UiSchema } from "@rjsf/utils";
 import CustomTextArea from "../Widgets/CustomTextArea";
-import SendIcon from '@mui/icons-material/Send';
-import {vars} from "../../theme/variables";
-import Timeline from '@mui/lab/Timeline';
-import TimelineItem from '@mui/lab/TimelineItem';
-import TimelineSeparator from '@mui/lab/TimelineSeparator';
-import TimelineConnector from '@mui/lab/TimelineConnector';
-import TimelineContent from '@mui/lab/TimelineContent';
-import MessageIcon from '@mui/icons-material/Message';
-import Typography from "@mui/material/Typography";
-import {Note} from "../../apiclient/backend";
-import {timeAgo} from "../../helpers/helpers";
-import {useDispatch} from "react-redux";
+import SendIcon from "@mui/icons-material/Send";
+import { vars } from "../../theme/variables";
 
-const TimeLineIcon = () => {
-  return <Box sx={{
-    padding: 8,
-    background: '#F2F4F7',
-    borderRadius: '50%',
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-    height: 30,
-    width: 30,
-  }}>
-    <MessageIcon sx={{fontSize: 16}} />
-  </Box>
-}
+
 const NoteForm = (props: any) => {
-  const { setRefresh, extraData } = props
-  const { schema, uiSchema } = jsonSchemas.getNoteSchema()
-  const [data, setData] = useState({})
+  const { setRefresh, extraData } = props;
+  const { schema, uiSchema } = jsonSchemas.getNoteSchema();
+  const [data, setData] = useState({});
 
   const clearNoteForm = () => {
-    setData({})
-    setRefresh(true)
-  }
+    setData({});
+    setRefresh(true);
+  };
   // TODO: set up the widgets for the schema
-  const uiFields = ["note",]
+  const uiFields = ["note"];
   const customSchema = {
     ...schema,
-    "title": ""
-  }
+    title: "",
+  };
 
   const customUiSchema: UiSchema = {
     ...uiSchema,
@@ -56,10 +31,23 @@ const NoteForm = (props: any) => {
       "ui:options": {
         placeholder: "Write your note",
         rows: 5,
-      }
+      },
     },
   };
 
+  const submitButtonProps = {
+    sx: {
+      padding: 0,
+      color: vars.darkBlue,
+      "&:hover": {
+        background: "transparent",
+        color: vars.mediumBlue,
+      },
+    },
+    className: "btn btn-primary",
+    startIcon: <SendIcon />,
+    label: "Send",
+  };
 
   return (
     <FormBase
@@ -72,26 +60,10 @@ const NoteForm = (props: any) => {
       clearOnSave={true}
       setter={clearNoteForm}
       extraData={extraData}
-    >
-      <Button
-        type="submit"
-        className="btn btn-primary"
-        sx={{
-          padding: 0,
-          color: vars.darkBlue,
+      submitButtonProps={submitButtonProps}
+      {...props}
+    />
+  );
+};
 
-          "&:hover": {
-            background: 'transparent',
-            color: vars.mediumBlue
-          }
-        }}
-        startIcon={<SendIcon />}
-      >
-        Send
-      </Button>
-    </FormBase>
-
-  )
-}
-
-export default NoteForm
+export default NoteForm;

--- a/frontend/src/components/Forms/SentenceAddForm.tsx
+++ b/frontend/src/components/Forms/SentenceAddForm.tsx
@@ -10,7 +10,7 @@ const SentenceAddForm = (props: any) => {
   const { format } = props;
   const { schema, uiSchema } = jsonSchemas.getSentenceSchema();
 
-  const [disabled, setDisabled] = React.useState(true)
+  const [disabled, setDisabled] = React.useState(true);
 
   const uiFields =
     format === "small"
@@ -73,6 +73,13 @@ const SentenceAddForm = (props: any) => {
     },
     "ui:order": uiOrder,
   };
+
+  const submitButtonProps = {
+    fullWidth: true,
+    variant: "contained",
+    label: "Done",
+  };
+
   return (
     <Box>
       <FormBase
@@ -83,10 +90,9 @@ const SentenceAddForm = (props: any) => {
         enableAutoSave={true}
         formIsValid={format === "create" && formIsValid}
         disableSubmitButton={setDisabled}
+        submitButtonProps={submitButtonProps}
         {...props}
-      >
-        <Button type='submit' variant='contained' fullWidth disabled={disabled}>Done</Button>
-      </FormBase>
+      />
     </Box>
   );
 };

--- a/frontend/src/components/Widgets/NotesFomList.tsx
+++ b/frontend/src/components/Widgets/NotesFomList.tsx
@@ -68,7 +68,7 @@ const NoteDetails = (props: any) => {
       }}>
         {
           noteList?.map((note: Note, index: number) =>
-            <TimelineItem>
+            <TimelineItem key={index}>
               <TimelineSeparator>
                 <TimeLineIcon />
                 {


### PR DESCRIPTION
SCKAN-77

Both issues are caused by programatically calling the submission of the form formRef.current.submit(), which hasn’t been yet solve by rjsf.

The workaround proposed by the library is to add a hidden submit button and call the click event on it. here :[Unable to trigger form submit/validation externally from the form · Issue #500 · rjsf-team/react-jsonschema-form](https://github.com/rjsf-team/react-jsonschema-form/issues/500)


https://user-images.githubusercontent.com/82731550/226964475-b0b393b8-2d97-4ff3-8816-3d41eb52dd18.mov


https://user-images.githubusercontent.com/82731550/226964538-e65b5196-355c-4335-ae06-d83671b6880f.mov

