### PR TITLE
SCKAN-137 change details layout at statement details page

### DIFF
--- a/frontend/src/Pages/StatementDetails.tsx
+++ b/frontend/src/Pages/StatementDetails.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react";
 import Box from "@mui/material/Box";
 import Paper from "@mui/material/Paper";
-import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import Grid from "@mui/material/Grid";
 import Tab from "@mui/material/Tab";
@@ -14,7 +13,7 @@ import { ConnectivityStatement } from "../apiclient/backend";
 import { userProfile } from "../services/UserService";
 import ProofingTab from "../components/ProofingTab/ProofingTab";
 import {SentenceStateChip} from "../components/Widgets/StateChip";
-import {formatDate, formatTime, SentenceLabels, StatementsLabels} from "../helpers/helpers";
+import {formatDate, formatTime, StatementsLabels} from "../helpers/helpers";
 import GroupedButtons from "../components/Widgets/CustomGroupedButtons";
 import Divider from "@mui/material/Divider";
 import NoteDetails from "../components/Widgets/NotesFomList";
@@ -166,7 +165,7 @@ const StatementDetails = () => {
 
           </Grid>
 
-          <Grid item md={12} lg={5}>
+          <Grid item xs={12} md={12} lg={5}>
             <Paper sx={{...sectionStyle, "& .MuiBox-root": { padding: 0 } }}>
               <Box>
                 <Typography variant="h5" mb={1}>

--- a/frontend/src/components/DistillationTab.tsx
+++ b/frontend/src/components/DistillationTab.tsx
@@ -1,21 +1,58 @@
 import React  from "react";
 import Typography from "@mui/material/Typography";
 import Grid from "@mui/material/Grid";
-import statementService from "../services/StatementService";
+import Box from "@mui/material/Box";
 import SentenceForm from "../components/Forms/SentenceForm";
-import SpeciesForm from "../components/Forms/SpeciesForm";
 import StatementForm from "../components/Forms/StatementForm";
 import Paper from "@mui/material/Paper";
 import SentenceStatementWithDois from "./SentenceStatementWithDois";
-import { useSectionStyle } from "../styles/styles";
+import { useSectionStyle, useGreyBgContainer} from "../styles/styles";
 import { useTheme } from "@mui/system";
+import StatementDetailsAccordion from "./TriageStatementSection/StatementDetailsAccordion";
+import ProvenancesForm from "./Forms/ProvenanceForm";
 
 const DistillationTab = ({ statement, setStatement, refreshStatement, disabled } : any) => {
   const theme = useTheme()
   const sectionStyle = useSectionStyle(theme)
+  const greyBgContainer = useGreyBgContainer(theme)
 
   return (
     <Grid container mb={2} spacing={2}>
+      <Grid item xs={12}>
+        <Paper sx={sectionStyle}>
+          <Typography variant="h5" mb={3}>
+          Knowledge Statement
+          </Typography>
+          <Box
+           sx={greyBgContainer}
+           >
+            <Paper sx={{...sectionStyle, p:0}}>
+              <StatementForm
+                statement={statement}
+                format="small"
+                setter={refreshStatement}
+                extraData={{ sentence_id: statement.sentence.id }}
+                uiFields={["knowledge_statement"]}
+                className='ks'
+                enableAutoSave={true}
+              />
+              <ProvenancesForm
+                provenancesData={statement.provenances}
+                extraData={{ connectivity_statement_id: statement.id }}
+                setter={refreshStatement}
+                className='provenance'
+              />
+                <StatementDetailsAccordion
+                  setter={refreshStatement}
+                  index={0}
+                  statement={statement}
+                  sentence={statement.sentence}
+                />
+            </Paper>
+          </Box>
+        </Paper>
+      </Grid>
+
       <Grid item xs={12}>
         <SentenceStatementWithDois statement={statement} setStatement={setStatement} refreshStatement={refreshStatement}/>
       </Grid>
@@ -26,40 +63,6 @@ const DistillationTab = ({ statement, setStatement, refreshStatement, disabled }
           format="small"
           disabled={true}
         />
-      </Grid>
-
-      <Grid item xs={12}>
-        <Paper sx={sectionStyle}>
-          <Typography variant="h5" mb={1}>
-            Statements Details
-          </Typography>
-          <SpeciesForm
-            data={statement.species}
-            extraData={{ parentId: statement.id, service: statementService }}
-            setter={refreshStatement}
-            disabled={true}
-          />
-          <StatementForm
-            disabled={disabled}
-            statement={statement}
-            format="small"
-            setter={setStatement}
-            extraData={{
-              statement_id: statement.id,
-              knowledge_statement: statement.knowledge_statement,
-            }}
-            enableAutoSave={true}
-            uiFields={[
-              "sex_id",
-              "apinatomy_model",
-              "additional_information",
-              "circuit_type",
-              "laterality",
-              "projection",
-              "phenotype_id",
-            ]}
-          />
-        </Paper>
       </Grid>
     </Grid>
   );

--- a/frontend/src/components/Forms/ProvenanceForm.tsx
+++ b/frontend/src/components/Forms/ProvenanceForm.tsx
@@ -43,7 +43,7 @@ const ProvenancesForm = (props: any) => {
     "ui:options": {
       disabled: !extraData.connectivity_statement_id || disabled,
       data: provenancesData?.map((row: Provenance) => ({id: row.id, label: row.uri, enableClick: isValidUrl(row.uri) })) || [],
-      placeholder: 'Enter Provenances (Press Enter to add a Provenance)',
+      placeholder: disabled ? null : 'Enter Provenances (Press Enter to add a Provenance)',
       removeChip: function(provenanceId: any) {
         provenanceService.delete(provenanceId, extraData.connectivity_statement_id)
         refresh()

--- a/frontend/src/components/ProofingTab/PathsBuilder.tsx
+++ b/frontend/src/components/ProofingTab/PathsBuilder.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Paper, Stack, Typography, Divider, Grid, Box, Table, TableBody } from "@mui/material";
 import { useTheme } from "@emotion/react";
-import { useSectionStyle } from "../../styles/styles";
+import { useSectionStyle, useGreyBgContainer } from "../../styles/styles";
 import StatementForm from "../Forms/StatementForm";
 import TableRow from "./TableRow";
 import { vars } from "../../theme/variables";
@@ -12,11 +12,7 @@ const PathsBuilder = (props: any) => {
   const { statement,  refreshStatement } = props;
   const theme = useTheme();
   const sectionStyle = useSectionStyle(theme);
-  const subSectionStyle = {
-    p:1,
-    borderRadius:'12px',
-    backgroundColor: 'info.light'
-  }
+  const subSectionStyle = useGreyBgContainer(theme)
   return (
     <Paper sx={{ ...sectionStyle, px: 0 }}>
         <Typography variant="h5" sx={{ px: 3, pb: 2 }}>

--- a/frontend/src/components/ProofingTab/ProofingTab.tsx
+++ b/frontend/src/components/ProofingTab/ProofingTab.tsx
@@ -3,7 +3,7 @@ import { Grid, Typography, Box, Stack, Divider, Paper } from "@mui/material";
 import StatementChart from "./StatementChart";
 import StatementWithProvenances from "../StatementWithProvenances";
 import CheckDuplicates from "../CheckForDuplicates/CheckDuplicatesDialog";
-import { useSectionStyle } from "../../styles/styles";
+import { useSectionStyle, useGreyBgContainer } from "../../styles/styles";
 import { useTheme } from "@mui/system";
 import PathsBuilder from "./PathsBuilder";
 
@@ -11,6 +11,7 @@ const ProofingTab = (props: any) => {
   const { statement, refreshStatement, setStatement } = props;
   const theme = useTheme();
   const sectionStyle = useSectionStyle(theme);
+  const greyBgContainer = useGreyBgContainer(theme)
 
   const hasJourney =
     statement.origin && statement.destination && statement.path.length > 0;
@@ -29,17 +30,12 @@ const ProofingTab = (props: any) => {
             }}
           >
             <Typography variant="h5" mb={3}>
-              Knowledge Statements
+              Knowledge Statement
             </Typography>
             <CheckDuplicates />
           </Stack>
           <Box
-            sx={{
-              background: "#F2F4F7",
-              borderRadius: "12px",
-              padding: "8px !important",
-              textAlign: "center",
-            }}
+            sx={greyBgContainer}
           >
             <StatementWithProvenances statement={statement} refreshStatement={refreshStatement} setStatement={setStatement}/>
           </Box>

--- a/frontend/src/components/SentenceStatementWithDois.tsx
+++ b/frontend/src/components/SentenceStatementWithDois.tsx
@@ -4,39 +4,31 @@ import Typography from "@mui/material/Typography";
 import Paper from "@mui/material/Paper";
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import {Box} from "@mui/material";
-import Divider from "@mui/material/Divider";
-import {useNavigate} from "react-router";
 import StatementWithProvenances from "./StatementWithProvenances";
 import { useSectionStyle } from "../styles/styles";
 import { useTheme } from "@mui/system";
 
-const SentenceStatementWithDois = ({ statement, setStatement, refreshStatement } : any) => {
-  const navigate = useNavigate();
+const SentenceStatementWithDois = ({ statement } : any) => {
   const theme = useTheme()
   const sectionStyle = useSectionStyle(theme)
 
   const openStatement = (statement: any) => {
-    navigate(`/statement/${statement?.id}`, {
-      replace: false
-    })
+    window.location.href = (`/statement/${statement?.id}`)
   }
 
   const otherStatements = statement?.sentence?.connectivity_statements.filter((row: any) => row?.id !== statement?.id)
+  
+  if (otherStatements.length === 0){
+    return null
+  }
+
   return (
     <Paper sx={sectionStyle}>
       <Typography variant="h5" mb={3}>
-        Knowledge Statements
+        Other Knowledge Statements
       </Typography>
-      <Box sx={{
-        background: '#F2F4F7',
-        borderRadius: '12px',
-        padding: '8px !important',
-        textAlign: 'center',
-      }}>
-        <StatementWithProvenances statement={statement} setStatement={setStatement} refreshStatement={refreshStatement} />
-      </Box>
-      <Divider sx={{margin: '24px 0'}}>Knowledge Statements from the same input Sentence</Divider>
       <Stack spacing={2}>
+        <Typography>Knowledge Statements from the same input Sentence</Typography>
         {
           otherStatements?.map((row: any )=>
             <Stack

--- a/frontend/src/components/TriageStatementSection/TriageStatementSection.tsx
+++ b/frontend/src/components/TriageStatementSection/TriageStatementSection.tsx
@@ -10,7 +10,7 @@ import statementService from "../../services/StatementService";
 import StatementForm from "../Forms/StatementForm";
 import ProvenancesForm from "../Forms/ProvenanceForm";
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
-import { useSectionStyle } from "../../styles/styles";
+import { useSectionStyle, useGreyBgContainer } from "../../styles/styles";
 import { useTheme } from "@mui/system";
 import { SentenceAvailableTransitionsEnum as SentenceStates } from "../../apiclient/backend";
 
@@ -19,6 +19,7 @@ const TriageStatementSection = (props: any) => {
 
   const theme = useTheme()
   const sectionStyle = useSectionStyle(theme)
+  const greyBgContainer = useGreyBgContainer(theme)
 
   const onDeleteStatement = (id: number) => {
     statementService.remove(id).then(() => refreshSentence());
@@ -31,9 +32,8 @@ const TriageStatementSection = (props: any) => {
   return (
     <Grid item xs={12}>
       <Box
-        p={1}
         mb={2}
-        sx={{ background: vars.bodyBgColor, borderRadius: "12px" }}
+        sx={greyBgContainer}
       >
         <Grid container spacing={1} alignItems="center">
           <Grid item xs={11}>

--- a/frontend/src/components/Widgets/NotesFomList.tsx
+++ b/frontend/src/components/Widgets/NotesFomList.tsx
@@ -11,6 +11,8 @@ import Typography from "@mui/material/Typography";
 import {Note} from "../../apiclient/backend";
 import {timeAgo} from "../../helpers/helpers";
 import NoteForm from "../Forms/NoteForm";
+import { useGreyBgContainer } from '../../styles/styles';
+import { useTheme } from "@mui/system";
 
 const TimeLineIcon = () => {
   return <Box sx={{
@@ -31,6 +33,9 @@ const NoteDetails = (props: any) => {
   const [noteList, setNoteList] = useState<Note[]>([])
   const [refresh, setRefresh] = useState(false)
 
+  const theme = useTheme()
+  const greyBgContainer = useGreyBgContainer(theme)
+
   useEffect(() => {
     const { connectivity_statement_id, sentence_id } = extraData
     if (connectivity_statement_id || sentence_id) {
@@ -44,8 +49,7 @@ const NoteDetails = (props: any) => {
   return (
     <Box display='flex' flexDirection='column' >
       <Box sx={{
-        background: '#F2F4F7',
-        borderRadius: '12px',
+        ...greyBgContainer,
         padding: '0 8px 8px !important',
         textAlign: 'center',
         "& .MuiGrid-item":

--- a/frontend/src/styles/styles.ts
+++ b/frontend/src/styles/styles.ts
@@ -12,3 +12,9 @@ export const useSectionStyle = (theme: any) => ({
   boxShadow: "none",
   padding: theme.spacing(3)
 })
+
+export const useGreyBgContainer = (theme: any) => ({
+  background: theme.palette.background.default,
+  borderRadius: '12px',
+  padding: theme.spacing(1)
+})


### PR DESCRIPTION
[SCKAN-137](https://metacell.atlassian.net/browse/SCKAN-137)

SCKAN-137 replace details section for accordion at statement details page

SCKAN-137 add other ks section at the bottom of statement details page

SCKAN-137 only show other ks section if any

SCKAN-137 move NLP sentence to the bottom of statement details page

https://github.com/MetaCell/sckan-composer/assets/82731550/64806657-5b86-41e7-ab33-865ee2c91f48



[SCKAN-137]: https://metacell.atlassian.net/browse/SCKAN-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ