### PR TITLE
Feature/sckan 148 enhancement

### DIFF
--- a/frontend/src/Pages/SentenceDetails.tsx
+++ b/frontend/src/Pages/SentenceDetails.tsx
@@ -123,9 +123,9 @@ const SentencesDetails = () => {
     ]);
   };
 
-  const handleMenuItemClick = (
-      event: React.MouseEvent<HTMLLIElement, MouseEvent>,
-      index: number
+const handleMenuItemClick = (
+    event: React.MouseEvent<HTMLLIElement, MouseEvent>,
+    index: number
   ) => {
     setSelectedIndex(index);
     setOpen(false);
@@ -138,38 +138,36 @@ const SentencesDetails = () => {
   useEffect(() => {
     if (sentenceId) {
       sentenceService
-          .getObject(sentenceId)
-          .then((sentence: Sentence) => {
-            setSentence(sentence);
-            const foundToBeReviewed = sentence.available_transitions.findIndex((transition) => transition === SentenceAvailableTransitionsEnum.ToBeReviewed)
-            setSelectedIndex(foundToBeReviewed && foundToBeReviewed !== -1 ? foundToBeReviewed : 0)
-            setConnectivityStatements(sentence.connectivity_statements.sort((a,b)=>a.id-b.id));
+        .getObject(sentenceId)
+        .then((sentence: Sentence) => {
+          setSentence(sentence);
+          const foundToBeReviewed = sentence.available_transitions.findIndex((transition) => transition === SentenceAvailableTransitionsEnum.ToBeReviewed)
+          setSelectedIndex(foundToBeReviewed && foundToBeReviewed !== -1 ? foundToBeReviewed : 0)
+          setConnectivityStatements(sentence.connectivity_statements.sort((a,b)=>a.id-b.id));
+          if (
+            sentence.owner &&
+            sentence.owner?.id !== userProfile.getUser().id
+          ) {
             if (
-                sentence.owner &&
-                sentence.owner?.id !== userProfile.getUser().id
+              window.confirm(
+                `This sentence is assigned to ${sentence.owner.first_name}, assign to yourself? To view the record without assigning ownership, select Cancel.`
+              )
             ) {
-              if (
-                  window.confirm(
-                      `This sentence is assigned to ${sentence.owner.first_name}, assign to yourself? To view the record without assigning ownership, select Cancel.`
-                  )
-              ) {
-                sentenceService
-                    .save({ ...sentence, owner_id: userProfile.getUser().id })
-                    .then((sentence: Sentence) => {
-                      setSentence(sentence);
-                    });
-              }
+              sentenceService
+                .save({ ...sentence, owner_id: userProfile.getUser().id })
+                .then((sentence: Sentence) => {
+                  setSentence(sentence);
+                });
             }
-          })
-          .finally(() => {
-            setRefetch(false);
-            setIsLoading(false);
-          });
+          }
+        })
+        .finally(() => {
+          setRefetch(false);
+          setLoading(false);
+        });
     }
   }, [sentenceId, refetch]);
-
-  console.log(isLoading)
-
+  
   if (isLoading) {
     return (
         <Backdrop open={isLoading} sx={{ color: '#fff', zIndex: (theme) => theme.zIndex.drawer + 1 }}>
@@ -181,114 +179,114 @@ const SentencesDetails = () => {
   const disabled = sentence.owner?.id !== userProfile.getUser().id;
 
   return (
-      <Grid p={6} container>
-        <Grid item xs={12} mb={4}>
-          <Grid container>
-            <Grid item xs={12} md={6}>
-              <Box>
-                <Typography variant="h3" mb={1}>
-                  Sentence Details #{sentenceId}{" "}
-                  <span>
+    <Grid p={6} container>
+      <Grid item xs={12} mb={4}>
+        <Grid container>
+          <Grid item xs={12} md={6}>
+            <Box>
+              <Typography variant="h3" mb={1}>
+                Sentence Details #{sentenceId}{" "}
+                <span>
                   <SentenceStateChip
-                      key={sentence?.state}
-                      value={sentence?.state}
+                    key={sentence?.state}
+                    value={sentence?.state}
                   />
                 </span>
-                </Typography>
-                <span>
+              </Typography>
+              <span>
                 Last Edited on {formatDate(sentence?.modified_date)},{" "}
-                  {formatTime(sentence?.modified_date)}
+                {formatTime(sentence?.modified_date)}
               </span>
-              </Box>
-            </Grid>
-            <Grid item xs={12} md={6} display="flex" justifyContent="flex-end">
-              {!disabled && sentence?.available_transitions?.length !== 0 && (
-                  <GroupedButtons
-                      handleClick={handleClick}
-                      selectedOption={
-                        SentenceLabels[sentence?.available_transitions[selectedIndex]]
-                      }
-                      options={sentence?.available_transitions}
-                      selectedIndex={selectedIndex}
-                      handleMenuItemClick={handleMenuItemClick}
-                      hasFormat={true}
-                      format={SentenceLabels}
-                  />
-              )}
-            </Grid>
+            </Box>
           </Grid>
-        </Grid>
-
-        <Grid item xs={12}>
-          <Grid container spacing={2}>
-            <Grid item xs={12} md={7}>
-              <Paper sx={{mb:2, ...sectionStyle}}>
-                <Grid container>
-                  <Grid item xs={12}>
-                    <Stack
-                        direction="row"
-                        justifyContent="space-between"
-                        sx={{
-                          "& .MuiButtonBase-root": {
-                            padding: 0,
-                          },
-                        }}
-                    >
-                      <Typography variant="h5" mb={3}>
-                        Knowledge Statements
-                      </Typography>
-                      <CheckDuplicates />
-                    </Stack>
-                  </Grid>
-                  {connectivityStatements?.map((statement, key) => (
-                      <TriageStatementSection
-                          statement={statement}
-                          key={key}
-                          index={key}
-                          refreshSentence={refreshSentence}
-                          setRefresh={setRefetch}
-                          setSentence={setSentence}
-                          sentence={sentence}
-                      />
-                  ))}
-                  <StyledAddStatementBtn
-                      startIcon={<AddCircleIcon />}
-                      variant="contained"
-                      fullWidth={true}
-                      onClick={onAddNewStatement}
-                  >
-                    Add a knowledge statement
-                  </StyledAddStatementBtn>
-                </Grid>
-              </Paper>
-              <SentenceForm
-                  data={sentence}
-                  disabled={disabled}
-                  format="small"
-                  setter={setSentence}
-                  enableAutoSave={true}
+          <Grid item xs={12} md={6} display="flex" justifyContent="flex-end">
+            {!disabled && sentence?.available_transitions?.length !== 0 && (
+              <GroupedButtons
+                handleClick={handleClick}
+                selectedOption={
+                  SentenceLabels[sentence?.available_transitions[selectedIndex]]
+                }
+                options={sentence?.available_transitions}
+                selectedIndex={selectedIndex}
+                handleMenuItemClick={handleMenuItemClick}
+                hasFormat={true}
+                format={SentenceLabels}
               />
-            </Grid>
-
-            <Grid item xs={12} md={5}>
-              <Paper sx={{...sectionStyle , "& .MuiBox-root": { padding: 0 }}}>
-                <Box>
-                  <Typography variant="h5" mb={1}>
-                    Notes
-                  </Typography>
-                </Box>
-                <TagForm
-                    data={sentence.tags}
-                    extraData={{ parentId: sentence.id, service: sentenceService }}
-                    setter={refreshSentence}
-                />
-                <Divider sx={{ margin: "36px 0" }} />
-                <NoteDetails extraData={{ sentence_id: sentence.id }} />
-              </Paper>
-            </Grid>
+            )}
           </Grid>
         </Grid>
       </Grid>
+
+      <Grid item xs={12}>
+        <Grid container spacing={2}>
+          <Grid item xs={12} md={7}>
+            <Paper sx={{mb:2, ...sectionStyle}}>
+              <Grid container>
+                <Grid item xs={12}>
+                  <Stack
+                    direction="row"
+                    justifyContent="space-between"
+                    sx={{
+                      "& .MuiButtonBase-root": {
+                        padding: 0,
+                      },
+                    }}
+                  >
+                    <Typography variant="h5" mb={3}>
+                      Knowledge Statements
+                    </Typography>
+                    <CheckDuplicates />
+                  </Stack>
+                </Grid>
+                {connectivityStatements?.map((statement, key) => (
+                  <TriageStatementSection
+                    statement={statement}
+                    key={key}
+                    index={key}
+                    refreshSentence={refreshSentence}
+                    setRefresh={setRefetch}
+                    setSentence={setSentence}
+                    sentence={sentence}
+                  />
+                ))}
+                <StyledAddStatementBtn
+                  startIcon={<AddCircleIcon />}
+                  variant="contained"
+                  fullWidth={true}
+                  onClick={onAddNewStatement}
+                >
+                  Add a knowledge statement
+                </StyledAddStatementBtn>
+              </Grid>
+            </Paper>
+            <SentenceForm
+              data={sentence}
+              disabled={disabled}
+              format="small"
+              setter={setSentence}
+              enableAutoSave={true}
+            />
+          </Grid>
+
+          <Grid item xs={12} md={5}>
+            <Paper sx={{...sectionStyle , "& .MuiBox-root": { padding: 0 }}}>
+              <Box>
+                <Typography variant="h5" mb={1}>
+                  Notes
+                </Typography>
+              </Box>
+              <TagForm
+                data={sentence.tags}
+                extraData={{ parentId: sentence.id, service: sentenceService }}
+                setter={refreshSentence}
+              />
+              <Divider sx={{ margin: "36px 0" }} />
+              <NoteDetails extraData={{ sentence_id: sentence.id }} />
+            </Paper>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Grid>
   );
 };
 

--- a/frontend/src/Pages/SentenceDetails.tsx
+++ b/frontend/src/Pages/SentenceDetails.tsx
@@ -99,6 +99,7 @@ const SentencesDetails = () => {
 
       } catch (error) {
         console.error("Error fetching the next sentence:", error);
+        setIsLoading(false)
       }
     };
 

--- a/frontend/src/Pages/SentenceDetails.tsx
+++ b/frontend/src/Pages/SentenceDetails.tsx
@@ -163,7 +163,7 @@ const handleMenuItemClick = (
         })
         .finally(() => {
           setRefetch(false);
-          setLoading(false);
+          setIsLoading(false);
         });
     }
   }, [sentenceId, refetch]);

--- a/frontend/src/Pages/SentenceDetails.tsx
+++ b/frontend/src/Pages/SentenceDetails.tsx
@@ -99,8 +99,6 @@ const SentencesDetails = () => {
 
       } catch (error) {
         console.error("Error fetching the next sentence:", error);
-      } finally {
-        setIsLoading(false);
       }
     };
 
@@ -169,6 +167,8 @@ const SentencesDetails = () => {
           });
     }
   }, [sentenceId, refetch]);
+
+  console.log(isLoading)
 
   if (isLoading) {
     return (

--- a/frontend/src/Pages/SentenceDetails.tsx
+++ b/frontend/src/Pages/SentenceDetails.tsx
@@ -52,7 +52,7 @@ const SentencesDetails = () => {
   const [sentence, setSentence] = useState({} as Sentence);
   const [isLoading, setIsLoading] = useState(true);
   const [connectivityStatements, setConnectivityStatements] =
-      useState<SentenceConnectivityStatement[]>();
+    useState<SentenceConnectivityStatement[]>();
 
   const [open, setOpen] = React.useState(false);
   const [selectedIndex, setSelectedIndex] = React.useState(0);
@@ -123,7 +123,7 @@ const SentencesDetails = () => {
     ]);
   };
 
-const handleMenuItemClick = (
+  const handleMenuItemClick = (
     event: React.MouseEvent<HTMLLIElement, MouseEvent>,
     index: number
   ) => {

--- a/frontend/src/Pages/SentenceDetails.tsx
+++ b/frontend/src/Pages/SentenceDetails.tsx
@@ -16,7 +16,7 @@ import Stack from "@mui/material/Stack";
 import GroupedButtons from "../components/Widgets/CustomGroupedButtons";
 import SentenceForm from "../components/Forms/SentenceForm";
 import Divider from "@mui/material/Divider";
-import { styled } from "@mui/material";
+import {Backdrop, CircularProgress, styled} from "@mui/material";
 import { vars } from "../theme/variables";
 import AddCircleIcon from "@mui/icons-material/AddCircle";
 import NoteDetails from "../components/Widgets/NotesFomList";
@@ -25,6 +25,7 @@ import { useSectionStyle } from "../styles/styles";
 import { useTheme } from "@mui/system";
 import {useAppSelector} from "../redux/hooks";
 import {useNavigate} from "react-router";
+import {QueryParams} from "../redux/sentenceSlice";
 
 const { bodyBgColor, darkBlue } = vars;
 
@@ -39,16 +40,24 @@ const StyledAddStatementBtn = styled(Button)(({ theme }) => ({
   },
 }));
 
+const shouldResearchWithoutFilters = (res: any, queryOptions: QueryParams) => {
+  return !(res && res.results && res.results.length) && wasSearchFiltered(queryOptions)
+}
+const wasSearchFiltered = (queryOptions: QueryParams) => {
+  return queryOptions.title || queryOptions.tagFilter || queryOptions.notes
+};
+
 const SentencesDetails = () => {
   const { sentenceId } = useParams();
   const [sentence, setSentence] = useState({} as Sentence);
-  const [loading, setLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
   const [connectivityStatements, setConnectivityStatements] =
-    useState<SentenceConnectivityStatement[]>();
+      useState<SentenceConnectivityStatement[]>();
 
   const [open, setOpen] = React.useState(false);
   const [selectedIndex, setSelectedIndex] = React.useState(0);
   const [refetch, setRefetch] = useState(false);
+
 
   const theme = useTheme()
   const sectionStyle = useSectionStyle(theme)
@@ -57,11 +66,8 @@ const SentencesDetails = () => {
   const navigate = useNavigate();
 
   const handleClick = () => {
-    const transition = sentence?.available_transitions[selectedIndex];
-    sentenceService
-      .doTransition(sentence, transition)
-      .then((sentence: Sentence) => {
-
+    const fetchNextSentence = async (sentence: Sentence) => {
+      try {
         const nextSentenceOptions = {
           ...queryOptions,
           stateFilter: ['open'] as ("open" | "to_be_reviewed" | "compose_later" | "compose_now" | "excluded" | "duplicate")[],
@@ -69,17 +75,39 @@ const SentencesDetails = () => {
           limit: 1,
           index: 0,
         };
-        sentenceService.getList(nextSentenceOptions).then((res) => {
-          if (res.results && res.results.length) {
-            // Navigate to the 'next' sentence's details page
-            const nextSentenceId = res.results[0].id;
-            navigate(`/sentence/${nextSentenceId}`);
-          } else {
-            // Navigate to the root/home directory
-            navigate('/');
-          }
-        });
-      });
+
+        let res = await sentenceService.getList(nextSentenceOptions);
+        if (shouldResearchWithoutFilters(res, queryOptions)) {
+          res = await sentenceService.getList({
+            notes: undefined,
+            tagFilter: undefined,
+            title: undefined,
+            ordering: queryOptions.ordering,
+            stateFilter: ['open'] as ("open" | "to_be_reviewed" | "compose_later" | "compose_now" | "excluded" | "duplicate")[],
+            exclude: [`${sentence.id}`],
+            limit: 1,
+            index: 0,
+          });
+        }
+
+        if (res && res.results && res.results.length) {
+          const nextSentenceId = res.results[0].id;
+          navigate(`/sentence/${nextSentenceId}`);
+        } else {
+          navigate('/');
+        }
+
+      } catch (error) {
+        console.error("Error fetching the next sentence:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    setIsLoading(true);
+    const transition = sentence?.available_transitions[selectedIndex];
+    sentenceService.doTransition(sentence, transition).then((sentence: Sentence) => fetchNextSentence(sentence))
+
   };
 
   const onAddNewStatement = () => {
@@ -98,8 +126,8 @@ const SentencesDetails = () => {
   };
 
   const handleMenuItemClick = (
-    event: React.MouseEvent<HTMLLIElement, MouseEvent>,
-    index: number
+      event: React.MouseEvent<HTMLLIElement, MouseEvent>,
+      index: number
   ) => {
     setSelectedIndex(index);
     setOpen(false);
@@ -112,151 +140,155 @@ const SentencesDetails = () => {
   useEffect(() => {
     if (sentenceId) {
       sentenceService
-        .getObject(sentenceId)
-        .then((sentence: Sentence) => {
-          setSentence(sentence);
-          const foundToBeReviewed = sentence.available_transitions.findIndex((transition) => transition === SentenceAvailableTransitionsEnum.ToBeReviewed)
-          setSelectedIndex(foundToBeReviewed && foundToBeReviewed !== -1 ? foundToBeReviewed : 0)
-          setConnectivityStatements(sentence.connectivity_statements.sort((a,b)=>a.id-b.id));
-          if (
-            sentence.owner &&
-            sentence.owner?.id !== userProfile.getUser().id
-          ) {
+          .getObject(sentenceId)
+          .then((sentence: Sentence) => {
+            setSentence(sentence);
+            const foundToBeReviewed = sentence.available_transitions.findIndex((transition) => transition === SentenceAvailableTransitionsEnum.ToBeReviewed)
+            setSelectedIndex(foundToBeReviewed && foundToBeReviewed !== -1 ? foundToBeReviewed : 0)
+            setConnectivityStatements(sentence.connectivity_statements.sort((a,b)=>a.id-b.id));
             if (
-              window.confirm(
-                `This sentence is assigned to ${sentence.owner.first_name}, assign to yourself? To view the record without assigning ownership, select Cancel.`
-              )
+                sentence.owner &&
+                sentence.owner?.id !== userProfile.getUser().id
             ) {
-              sentenceService
-                .save({ ...sentence, owner_id: userProfile.getUser().id })
-                .then((sentence: Sentence) => {
-                  setSentence(sentence);
-                });
+              if (
+                  window.confirm(
+                      `This sentence is assigned to ${sentence.owner.first_name}, assign to yourself? To view the record without assigning ownership, select Cancel.`
+                  )
+              ) {
+                sentenceService
+                    .save({ ...sentence, owner_id: userProfile.getUser().id })
+                    .then((sentence: Sentence) => {
+                      setSentence(sentence);
+                    });
+              }
             }
-          }
-        })
-        .finally(() => {
-          setRefetch(false);
-          setLoading(false);
-        });
+          })
+          .finally(() => {
+            setRefetch(false);
+            setIsLoading(false);
+          });
     }
   }, [sentenceId, refetch]);
 
-  if (loading) {
-    return <div>Loading...</div>;
+  if (isLoading) {
+    return (
+        <Backdrop open={isLoading} sx={{ color: '#fff', zIndex: (theme) => theme.zIndex.drawer + 1 }}>
+          <CircularProgress color="inherit" />
+        </Backdrop>
+    )
   }
 
   const disabled = sentence.owner?.id !== userProfile.getUser().id;
 
   return (
-    <Grid p={6} container>
-      <Grid item xs={12} mb={4}>
-        <Grid container>
-          <Grid item xs={12} md={6}>
-            <Box>
-              <Typography variant="h3" mb={1}>
-                Sentence Details #{sentenceId}{" "}
-                <span>
+      <Grid p={6} container>
+        <Grid item xs={12} mb={4}>
+          <Grid container>
+            <Grid item xs={12} md={6}>
+              <Box>
+                <Typography variant="h3" mb={1}>
+                  Sentence Details #{sentenceId}{" "}
+                  <span>
                   <SentenceStateChip
-                    key={sentence?.state}
-                    value={sentence?.state}
+                      key={sentence?.state}
+                      value={sentence?.state}
                   />
                 </span>
-              </Typography>
-              <span>
-                Last Edited on {formatDate(sentence?.modified_date)},{" "}
-                {formatTime(sentence?.modified_date)}
-              </span>
-            </Box>
-          </Grid>
-          <Grid item xs={12} md={6} display="flex" justifyContent="flex-end">
-            {!disabled && sentence?.available_transitions?.length !== 0 && (
-              <GroupedButtons
-                handleClick={handleClick}
-                selectedOption={
-                  SentenceLabels[sentence?.available_transitions[selectedIndex]]
-                }
-                options={sentence?.available_transitions}
-                selectedIndex={selectedIndex}
-                handleMenuItemClick={handleMenuItemClick}
-                hasFormat={true}
-                format={SentenceLabels}
-              />
-            )}
-          </Grid>
-        </Grid>
-      </Grid>
-
-      <Grid item xs={12}>
-        <Grid container spacing={2}>
-          <Grid item xs={12} md={7}>
-            <Paper sx={{mb:2, ...sectionStyle}}>
-              <Grid container>
-                <Grid item xs={12}>
-                  <Stack
-                    direction="row"
-                    justifyContent="space-between"
-                    sx={{
-                      "& .MuiButtonBase-root": {
-                        padding: 0,
-                      },
-                    }}
-                  >
-                    <Typography variant="h5" mb={3}>
-                      Knowledge Statements
-                    </Typography>
-                    <CheckDuplicates />
-                  </Stack>
-                </Grid>
-                {connectivityStatements?.map((statement, key) => (
-                  <TriageStatementSection
-                    statement={statement}
-                    key={key}
-                    index={key}
-                    refreshSentence={refreshSentence}
-                    setRefresh={setRefetch}
-                    setSentence={setSentence}
-                    sentence={sentence}
-                  />
-                ))}
-                <StyledAddStatementBtn
-                  startIcon={<AddCircleIcon />}
-                  variant="contained"
-                  fullWidth={true}
-                  onClick={onAddNewStatement}
-                >
-                  Add a knowledge statement
-                </StyledAddStatementBtn>
-              </Grid>
-            </Paper>
-            <SentenceForm
-              data={sentence}
-              disabled={disabled}
-              format="small"
-              setter={setSentence}
-              enableAutoSave={true}
-            />
-          </Grid>
-
-          <Grid item xs={12} md={5}>
-            <Paper sx={{...sectionStyle , "& .MuiBox-root": { padding: 0 }}}>
-              <Box>
-                <Typography variant="h5" mb={1}>
-                  Notes
                 </Typography>
+                <span>
+                Last Edited on {formatDate(sentence?.modified_date)},{" "}
+                  {formatTime(sentence?.modified_date)}
+              </span>
               </Box>
-              <TagForm
-                data={sentence.tags}
-                extraData={{ parentId: sentence.id, service: sentenceService }}
-                setter={refreshSentence}
+            </Grid>
+            <Grid item xs={12} md={6} display="flex" justifyContent="flex-end">
+              {!disabled && sentence?.available_transitions?.length !== 0 && (
+                  <GroupedButtons
+                      handleClick={handleClick}
+                      selectedOption={
+                        SentenceLabels[sentence?.available_transitions[selectedIndex]]
+                      }
+                      options={sentence?.available_transitions}
+                      selectedIndex={selectedIndex}
+                      handleMenuItemClick={handleMenuItemClick}
+                      hasFormat={true}
+                      format={SentenceLabels}
+                  />
+              )}
+            </Grid>
+          </Grid>
+        </Grid>
+
+        <Grid item xs={12}>
+          <Grid container spacing={2}>
+            <Grid item xs={12} md={7}>
+              <Paper sx={{mb:2, ...sectionStyle}}>
+                <Grid container>
+                  <Grid item xs={12}>
+                    <Stack
+                        direction="row"
+                        justifyContent="space-between"
+                        sx={{
+                          "& .MuiButtonBase-root": {
+                            padding: 0,
+                          },
+                        }}
+                    >
+                      <Typography variant="h5" mb={3}>
+                        Knowledge Statements
+                      </Typography>
+                      <CheckDuplicates />
+                    </Stack>
+                  </Grid>
+                  {connectivityStatements?.map((statement, key) => (
+                      <TriageStatementSection
+                          statement={statement}
+                          key={key}
+                          index={key}
+                          refreshSentence={refreshSentence}
+                          setRefresh={setRefetch}
+                          setSentence={setSentence}
+                          sentence={sentence}
+                      />
+                  ))}
+                  <StyledAddStatementBtn
+                      startIcon={<AddCircleIcon />}
+                      variant="contained"
+                      fullWidth={true}
+                      onClick={onAddNewStatement}
+                  >
+                    Add a knowledge statement
+                  </StyledAddStatementBtn>
+                </Grid>
+              </Paper>
+              <SentenceForm
+                  data={sentence}
+                  disabled={disabled}
+                  format="small"
+                  setter={setSentence}
+                  enableAutoSave={true}
               />
-              <Divider sx={{ margin: "36px 0" }} />
-              <NoteDetails extraData={{ sentence_id: sentence.id }} />
-            </Paper>
+            </Grid>
+
+            <Grid item xs={12} md={5}>
+              <Paper sx={{...sectionStyle , "& .MuiBox-root": { padding: 0 }}}>
+                <Box>
+                  <Typography variant="h5" mb={1}>
+                    Notes
+                  </Typography>
+                </Box>
+                <TagForm
+                    data={sentence.tags}
+                    extraData={{ parentId: sentence.id, service: sentenceService }}
+                    setter={refreshSentence}
+                />
+                <Divider sx={{ margin: "36px 0" }} />
+                <NoteDetails extraData={{ sentence_id: sentence.id }} />
+              </Paper>
+            </Grid>
           </Grid>
         </Grid>
       </Grid>
-    </Grid>
   );
 };
 

--- a/frontend/src/components/EntityDataGrid.tsx
+++ b/frontend/src/components/EntityDataGrid.tsx
@@ -31,6 +31,7 @@ import {
 } from "../redux/statementSlice";
 import { useAppDispatch } from "../redux/hooks";
 import { useNavigate } from "react-router";
+import Stack from "@mui/material/Stack";
 
 interface DataGridProps {
   entityType: "sentence" | "statement";
@@ -189,6 +190,11 @@ const EntityDataGrid = (props: DataGridProps) => {
         }
         components={{
           Pagination: CustomPagination,
+          NoRowsOverlay: () => (
+              <Stack height="100%" alignItems="center" justifyContent="center">
+                No sentences to display, clear your filter or modify your search criteria
+              </Stack>
+          )
         }}
       />
     </Box>

--- a/frontend/src/services/SentenceService.ts
+++ b/frontend/src/services/SentenceService.ts
@@ -16,7 +16,7 @@ class SentenceService extends AbstractService {
   async getObject(id: string): Promise<Sentence> {
     return composerApi.composerSentenceRetrieve(Number(id)).then((response: any) => response.data)
   }
-  async doTransition(sentence: Sentence, transition: string) {
+  async doTransition(sentence: Sentence, transition: string): Promise<Sentence> {
     return composerApi.composerSentenceDoTransitionCreate(sentence.id, transition, sentence).then((response: any) => response.data)
   }
   async addTag(id: number, tagId: number): Promise<Sentence> {


### PR DESCRIPTION
Second iteration of https://metacell.atlassian.net/browse/SCKAN-148 after the meeting feedback:

- Implements fallback to **any** open sentence when we have no results for a **filtered** open sentence (I though this was already in place but after checking I realized it was not so I added it now)
- Adds circular progress on navigation to a new sentence
- Fixes premature leave of loading state (which was the cause of the alert showing up with the new sentenceID in the sentence details page).
- Updates data grid no rows message

https://github.com/MetaCell/sckan-composer/assets/19196034/6f2155d7-0a95-405d-949a-5ac05e1fe556

https://github.com/MetaCell/sckan-composer/assets/19196034/f03a3898-ca34-4d40-83ab-bc51c8b7601f


