### PR TITLE
SCKAN-182 'Clear search' button does nothing

### DIFF
--- a/frontend/src/components/Widgets/CustomAutocompleteForwardConnection.tsx
+++ b/frontend/src/components/Widgets/CustomAutocompleteForwardConnection.tsx
@@ -204,7 +204,7 @@ export const CustomAutocompleteForwardConnection = ({
   };
 
   const handleInputChange = (value: string) => {
-    if (value !== "" && value !== undefined) {
+    if (value !== undefined) {
       setSearchValue(value);
     }
   };
@@ -289,6 +289,7 @@ export const CustomAutocompleteForwardConnection = ({
         onChange={(e, value) => onChange(e, value)}
         groupBy={(option: Option) => option.relation}
         value={selectedOptions}
+        inputValue={searchValue}
         getOptionLabel={(option: string | Option) => {
           return typeof option === "string"
             ? option
@@ -522,7 +523,7 @@ export const CustomAutocompleteForwardConnection = ({
                 <Typography variant="body1" marginBottom={2}>
 			We couldn't find any records with this origin in the database.                  
                 </Typography>
-                <Button variant="outlined">Clear search</Button>
+                <Button variant="outlined" onClick={() => setSearchValue("")}>Clear search</Button>
               </Box>
             )}
           </Paper>


### PR DESCRIPTION
Issue #SCKAN-182
Problem: 'Clear search' button does nothing
Solution: 
In order to solve this there should be state to control input value, so I added this state. 
This inputValue depends on searchValue if it is empty or has some value so, in order to clear search, I added listener function, which sets search value to an empty string whenever this 'clear search' button is clicked.

here is the video of the solution

https://github.com/MetaCell/sckan-composer/assets/67194168/ee52ee94-5d1a-47df-b877-ffc4b70823f6

