### PR TITLE
SCKAN-231 feat: Only search for forward connections when destinations…

### DIFF
--- a/frontend/src/services/CustomDropdownService.ts
+++ b/frontend/src/services/CustomDropdownService.ts
@@ -209,17 +209,21 @@ export async function searchForwardConnection(
   statement: ConnectivityStatement,
   excludeIds?: number[],
 ): Promise<Option[]> {
+
   try {
+    const forwardConnectionOrigins = statement.destinations?.flatMap(
+        (destination) =>
+            destination.anatomical_entities?.map((entity) => entity.id) ?? [],
+        ) ?? [];
+    if (forwardConnectionOrigins.length == 0) {
+      return []
+    }
     const sameSentencePromise = connectivityStatementService.getList({
       ...queryOptions,
       excludeIds,
       excludeSentenceId: undefined,
       sentenceId: statement.sentence_id,
-      origins:
-        statement.destinations?.flatMap(
-          (destination) =>
-            destination.anatomical_entities?.map((entity) => entity.id) ?? [],
-        ) ?? [],
+      origins: forwardConnectionOrigins,
       knowledgeStatement: searchValue,
     });
 
@@ -228,11 +232,7 @@ export async function searchForwardConnection(
       excludeIds,
       excludeSentenceId: statement.sentence_id,
       sentenceId: undefined,
-      origins:
-        statement.destinations?.flatMap(
-          (destination) =>
-            destination.anatomical_entities?.map((entity) => entity.id) ?? [],
-        ) ?? [],
+      origins: forwardConnectionOrigins,
       knowledgeStatement: searchValue,
     });
 


### PR DESCRIPTION
closes https://metacell.atlassian.net/browse/SCKAN-231
closes https://metacell.atlassian.net/browse/SCKAN-180

> The problem wasn't really in the backend but rather the frontend api service that doesn't include the origins property when it's an empty array. That code is automatically generated so we can't really change it. Instead I added a check in the function that has the logic to fetch for forward connections to only do that when there are destinations
