### PR TITLE
SCKAN-250 fix: Remove CircuitType.UNKNOWN from ingestion

### DIFF
--- a/backend/composer/services/cs_ingestion/cs_ingestion_services.py
+++ b/backend/composer/services/cs_ingestion/cs_ingestion_services.py
@@ -339,10 +339,10 @@ def get_circuit_type(statement: Dict):
     if statement[CIRCUIT_TYPE]:
         if len(statement[CIRCUIT_TYPE]) > 1:
             logger_service.add_anomaly(LoggableAnomaly(statement[ID], None, f'Multiple circuit types found'))
-        return CIRCUIT_TYPE_MAPPING.get(statement[CIRCUIT_TYPE][0], CircuitType.UNKNOWN)
+        return CIRCUIT_TYPE_MAPPING.get(statement[CIRCUIT_TYPE][0], None)
     else:
         logger_service.add_anomaly(LoggableAnomaly(statement[ID], None, f'No circuit type found.'))
-        return CircuitType.UNKNOWN
+        return None
 
 
 def get_phenotype(statement: Dict) -> Optional[Phenotype]:

--- a/backend/composer/services/cs_ingestion/helpers.py
+++ b/backend/composer/services/cs_ingestion/helpers.py
@@ -1,8 +1,7 @@
 import logging
-from typing import Optional, Dict
 
 from composer.enums import CircuitType
-from composer.models import AnatomicalEntity, ConnectivityStatement
+from composer.models import AnatomicalEntity
 
 ID = "id"
 ORIGINS = "origins"
@@ -26,7 +25,7 @@ CIRCUIT_TYPE_MAPPING = {
     "http://uri.interlex.org/tgbugs/uris/readable/ProjectionPhenotype": CircuitType.PROJECTION,
     "http://uri.interlex.org/tgbugs/uris/readable/MotorPhenotype": CircuitType.MOTOR,
     "http://uri.interlex.org/tgbugs/uris/readable/SensoryPhenotype": CircuitType.SENSORY,
-    "": CircuitType.UNKNOWN
+    "": None
 }
 
 VALIDATION_ERRORS = "validation_errors"


### PR DESCRIPTION
Updates ingestion based after changes from https://metacell.atlassian.net/browse/SCKAN-250.

- Removes references to the no longer available CircuitType.UNKNOWN