### PR TITLE
SCKAN-259 fix: Update transition permissions with explicit system use…

### DIFF
--- a/backend/composer/services/state_services.py
+++ b/backend/composer/services/state_services.py
@@ -143,10 +143,10 @@ class ConnectivityStatementStateService(StateServiceMixin):
 
     @staticmethod
     def has_permission_to_transition_to_compose_now(connectivity_statement, user) -> bool:
-        profile = get_user_profile(user=user)
         if is_system_user(user) and connectivity_statement.state == CSState.DRAFT:
             return True
 
+        profile = get_user_profile(user=user)
         if profile.is_curator and connectivity_statement.state in [CSState.INVALID, CSState.IN_PROGRESS]:
             return True
 
@@ -154,6 +154,9 @@ class ConnectivityStatementStateService(StateServiceMixin):
 
     @staticmethod
     def has_permission_to_transition_to_in_progress(connectivity_statement, user) -> bool:
+        if is_system_user(user):
+            return False
+
         profile = get_user_profile(user=user)
         if profile.is_curator and connectivity_statement.state in [CSState.COMPOSE_NOW, CSState.REVISE]:
             return True
@@ -178,6 +181,10 @@ class ConnectivityStatementStateService(StateServiceMixin):
 
     @staticmethod
     def has_permission_to_transition_to_to_be_reviewed(connectivity_statement, user) -> bool:
+
+        if is_system_user(user):
+            return False
+
         profile = get_user_profile(user=user)
         if profile.is_curator and connectivity_statement.state == CSState.IN_PROGRESS:
             return True
@@ -189,16 +196,24 @@ class ConnectivityStatementStateService(StateServiceMixin):
 
     @staticmethod
     def has_permission_to_transition_to_rejected(connectivity_statement, user) -> bool:
+        if is_system_user(user):
+            return False
+
         profile = get_user_profile(user=user)
         return profile.is_reviewer or user.is_staff
 
     @staticmethod
     def has_permission_to_transition_to_revise(connectivity_statement, user) -> bool:
+        if is_system_user(user):
+            return False
+
         profile = get_user_profile(user=user)
         return profile.is_reviewer or user.is_staff
 
     @staticmethod
     def has_permission_to_transition_to_npo_approval(connectivity_statement, user) -> bool:
+        if is_system_user(user):
+            return False
         profile = get_user_profile(user=user)
         return profile.is_reviewer or user.is_staff
 


### PR DESCRIPTION
closes https://metacell.atlassian.net/browse/SCKAN-259 


<details>
  <summary>the export through the dashboard is broken</summary>
  
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.9/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/src/app/composer/views.py", line 45, in export
    file_path, export_batch = export_connectivity_statements(qs=qs, user=request.user, folder_path=None)
  File "/usr/src/app/composer/services/export_services.py", line 566, in export_connectivity_statements
    do_transition_to_exported(export_batch, user)
  File "/usr/src/app/composer/services/export_services.py", line 511, in do_transition_to_exported
    available_transitions = [
  File "/usr/src/app/composer/services/export_services.py", line 511, in <listcomp>
    available_transitions = [
  File "/usr/local/lib/python3.9/site-packages/django_fsm/__init__.py", line 154, in get_available_user_FIELD_transitions
    if transition.has_perm(instance, user):
  File "/usr/local/lib/python3.9/site-packages/django_fsm/__init__.py", line 118, in has_perm
    return bool(self.permission(instance, user))
  File "/usr/src/app/composer/services/state_services.py", line 197, in has_permission_to_transition_to_revise
    profile = get_user_profile(user=user)
  File "/usr/src/app/composer/services/state_services.py", line 255, in get_user_profile
    return Profile.objects.get(user=user)
  File "/usr/local/lib/python3.9/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/django/db/models/query.py", line 650, in get
    raise self.model.DoesNotExist(
composer.models.Profile.DoesNotExist: Profile matching query does not exist.
```
  
</details>

Problem:
- Transition permission checks were relying on the user profile to define who has permission.
- System user has no profile.
- On export, we check which transitions are available to the system user by testing all of them.

Solution:
- Explicitly check against permission of the system user prior to retrieval of user's profile.

![image](https://github.com/MetaCell/sckan-composer/assets/19196034/af2a1776-6adf-4859-a6e9-67205797f506)
