### PR TITLE
Feature/csckan-277

### DIFF
--- a/backend/composer/models.py
+++ b/backend/composer/models.py
@@ -269,6 +269,18 @@ class AnatomicalEntity(models.Model):
             return f"{region_name},{layer_name}"
         else:
             return "Unnamed Entity"
+        
+    @property
+    def ontology_uri(self):
+        if self.simple_entity:
+            return self.simple_entity.ontology_uri
+        elif self.region_layer:
+            layer_uri = self.region_layer.layer.ontology_uri if self.region_layer.layer else ""
+            region_uri = self.region_layer.region.ontology_uri if self.region_layer.region else ""
+            return f"{region_uri},{layer_uri}"
+        else:
+            return None
+
 
     def __str__(self):
         return self.name

--- a/backend/composer/models.py
+++ b/backend/composer/models.py
@@ -261,25 +261,13 @@ class AnatomicalEntity(models.Model):
 
     @property
     def name(self):
-        if self.simple_entity:
-            return self.simple_entity.name
-        elif self.region_layer:
-            layer_name = self.region_layer.layer.name if self.region_layer.layer else "No Layer"
-            region_name = self.region_layer.region.name if self.region_layer.region else "No Region"
-            return f"{region_name},{layer_name}"
-        else:
-            return "Unnamed Entity"
+        return self.simple_entity.name if self.simple_entity \
+            else f'{self.region_layer.region.name},{self.region_layer.layer.name}'
         
     @property
     def ontology_uri(self):
-        if self.simple_entity:
-            return self.simple_entity.ontology_uri
-        elif self.region_layer:
-            layer_uri = self.region_layer.layer.ontology_uri if self.region_layer.layer else ""
-            region_uri = self.region_layer.region.ontology_uri if self.region_layer.region else ""
-            return f"{region_uri},{layer_uri}"
-        else:
-            return None
+        return self.simple_entity.ontology_uri if self.simple_entity \
+            else f'{self.region_layer.region.ontology_uri},{self.region_layer.layer.ontology_uri}'
 
 
     def __str__(self):


### PR DESCRIPTION
Jira Link - https://metacell.atlassian.net/browse/SCKAN-277

Implementation/Requirements :
- show AE name instead of synonyms in Connected From 
- show (region, layer) uri in identifier when it is RegionLayer AE

When the destination is one of RegionLayer AE, it shows as -> Region, Layer in the "Connected from". This is since RegionLayerPair is also AnatomicalEntity.
![image](https://github.com/MetaCell/sckan-composer/assets/59233227/90d225dc-1e71-4994-a106-6316ebb4299c)

@ddelpiano thoughts?



When origin is a RegionLayer AE, the identifier is a pair separated by a comma. uri for - region, layer
![Screenshot 2024-03-29 122140](https://github.com/MetaCell/sckan-composer/assets/59233227/06a6a617-83a8-476f-a742-15c3bb8b9855)
