### PR TITLE
Feature/esckan-35 - Composer REST new generic endpoint

### DIFF
--- a/backend/composer/api/serializers.py
+++ b/backend/composer/api/serializers.py
@@ -681,7 +681,11 @@ class GenericConnectivityStatementSerializer(ConnectivityStatementSerializer):
         fields = (
             "id",
             "sentence_id",
+            "species",
             "origins",
             "vias",
             "destinations",
+            "apinatomy_model",
+            "phenotype_id",
+            "phenotype",
         )

--- a/backend/composer/api/serializers.py
+++ b/backend/composer/api/serializers.py
@@ -673,3 +673,15 @@ class ConnectivityStatementUpdateSerializer(ConnectivityStatementSerializer):
             "statement_preview",
             "errors"
         )
+
+
+class GenericConnectivityStatementSerializer(ConnectivityStatementSerializer):
+    """Generic Connectivity Statement"""
+    class Meta(ConnectivityStatementSerializer.Meta):
+        fields = (
+            "id",
+            "sentence_id",
+            "origins",
+            "vias",
+            "destinations",
+        )

--- a/backend/composer/api/urls.py
+++ b/backend/composer/api/urls.py
@@ -5,6 +5,7 @@ from .views import (
     AnatomicalEntityViewSet,
     PhenotypeViewSet,
     ConnectivityStatementViewSet,
+    GenericConnectivityStatementViewSet,
     jsonschemas,
     NoteViewSet,
     ProfileViewSet,
@@ -26,6 +27,11 @@ router.register(
     r"connectivity-statement",
     ConnectivityStatementViewSet,
     basename="connectivity-statement",
+)
+router.register(
+	r"connectivity-statement-generic",
+	GenericConnectivityStatementViewSet,
+    basename="connectivity-statement-generic",
 )
 router.register(r"note", NoteViewSet, basename="note")
 router.register(r"note-tag", TagViewSet, basename="note-tag")

--- a/backend/composer/api/views.py
+++ b/backend/composer/api/views.py
@@ -17,6 +17,7 @@ from composer.services.state_services import (
 from .filtersets import (
     SentenceFilter,
     ConnectivityStatementFilter,
+    GenericConnectivityStatementFilter,
     AnatomicalEntityFilter,
     NoteFilter,
     ViaFilter,
@@ -26,6 +27,7 @@ from .serializers import (
     AnatomicalEntitySerializer,
     PhenotypeSerializer,
     ConnectivityStatementSerializer,
+    GenericConnectivityStatementSerializer,
     NoteSerializer,
     ProfileSerializer,
     SentenceSerializer,
@@ -344,6 +346,32 @@ class ConnectivityStatementViewSet(
     def partial_update(self, request, *args, **kwargs):
         return super().partial_update(request, *args, **kwargs)
 
+
+class GenericConnectivityStatementViewSet(
+    viewsets.ModelViewSet,
+):
+    """
+    GenericConnectivityStatement that only allows GET to get the list of ConnectivityStatements
+    """
+    queryset = ConnectivityStatement.objects.all()
+    serializer_class = GenericConnectivityStatementSerializer
+    permission_classes = [
+        permissions.AllowAny,
+    ]
+    filterset_class = GenericConnectivityStatementFilter
+    http_method_names = ['get']
+
+    @property
+    def allowed_methods(self):
+        return ['GET']
+
+    def get_serializer_class(self):
+        return GenericConnectivityStatementSerializer
+    
+
+    def get_queryset(self):
+        return ConnectivityStatement.objects.filter_by_exported_state()
+        
 
 class TagViewSet(viewsets.ReadOnlyModelViewSet):
     """

--- a/backend/composer/models.py
+++ b/backend/composer/models.py
@@ -269,6 +269,18 @@ class AnatomicalEntity(models.Model):
             return f"{region_name},{layer_name}"
         else:
             return "Unnamed Entity"
+        
+    @property
+    def ontology_uri(self):
+        if self.simple_entity:
+            return self.simple_entity.ontology_uri
+        elif self.region_layer:
+            layer_uri = self.region_layer.layer.ontology_uri if self.region_layer.layer else ""
+            region_uri = self.region_layer.region.ontology_uri if self.region_layer.region else ""
+            return f"{region_uri},{layer_uri}"
+        else:
+            return None
+
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
Jira Card - https://metacell.atlassian.net/browse/ESCKAN-35


A new generic endpoint for Connectivity statement.
- Add new endpoint `connectivity-statement-generic` with new serializer - GenericConnectivityStatementSerializer and filterset - GenericConnectivityStatementFilter.
- Only GET allow.
- filter by 4 query parameters - origin, via, destination, population uris
-  Only exported Connectivity statements are shown. As mentioned in [lucidcharts](https://lucid.app/lucidchart/7197f056-4f35-4453-8f27-369a045ad40b/edit?invitationId=inv_d553a755-dc0e-44bc-ac75-f15e4be38e13&page=.eqhIXv27vP.#)

<br>

Default behaviors of the filters.
- When multiple population uris are selected - OR is applied.
- When one population and one via/origin/destination is selected - AND is applied


Source on Custom Filter with [django_filters](https://django-filter.readthedocs.io/en/stable/ref/filters.html#multiplechoicefilter)


Short video demo

https://github.com/MetaCell/sckan-composer/assets/59233227/24cedd2b-7fc7-4530-b103-cf46acceb40c


