### PR TITLE
SCKAN-282 feat: Allow transition from Exported to Compose Now

### DIFF
--- a/backend/composer/models.py
+++ b/backend/composer/models.py
@@ -516,7 +516,8 @@ class ConnectivityStatement(models.Model):
         source=[
             CSState.DRAFT,
             CSState.IN_PROGRESS,
-            CSState.INVALID
+            CSState.INVALID,
+            CSState.EXPORTED,
         ],
         target=CSState.COMPOSE_NOW,
         permission=ConnectivityStatementStateService.has_permission_to_transition_to_compose_now,


### PR DESCRIPTION
Closes https://metacell.atlassian.net/browse/SCKAN-282

The authorization check is done [here](https://github.com/MetaCell/sckan-composer/blob/feature/SCKAN-282/backend/composer/services/state_services.py#L153)


https://github.com/MetaCell/sckan-composer/assets/19196034/3ca3adb1-ea13-4532-a4fb-0d81ef406152


