### PR TITLE
Feature/esckan-35 -  KnowledgeStatement endpoint fixes

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -67,9 +67,13 @@ INSTALLED_APPS = [
     "nested_admin",
     "django.contrib.admin",
     "social_django",
+
+    #
+    "corsheaders",
 ]
 
 MIDDLEWARE = [
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",

--- a/backend/composer/api/handlers.py
+++ b/backend/composer/api/handlers.py
@@ -1,0 +1,10 @@
+from corsheaders.signals import check_request_enabled
+
+
+def cors_allow_api_to_origins(sender, request, **kwargs):
+    """
+    Allow API requests to be made from the specified origins.
+	"""
+    return request.path == '/api/composer/knowledge-statement/'
+
+check_request_enabled.connect(cors_allow_api_to_origins)

--- a/backend/composer/api/handlers.py
+++ b/backend/composer/api/handlers.py
@@ -1,10 +1,9 @@
 from corsheaders.signals import check_request_enabled
 
 
-def cors_allow_api_to_origins(sender, request, **kwargs):
-    """
-    Allow API requests to be made from the specified origins.
-	"""
+def cors_allow_knowledge_statement_request(sender, request, **kwargs):
+    """Allow API requests to be made for the knowledge statement."""
     return request.path == '/api/composer/knowledge-statement/'
 
-check_request_enabled.connect(cors_allow_api_to_origins)
+
+check_request_enabled.connect(cors_allow_knowledge_statement_request)

--- a/backend/composer/api/serializers.py
+++ b/backend/composer/api/serializers.py
@@ -683,6 +683,18 @@ class ConnectivityStatementUpdateSerializer(ConnectivityStatementSerializer):
 
 class KnowledgeStatementSerializer(ConnectivityStatementSerializer):
     """Knowledge Statement"""
+    def to_representation(self, instance):
+        representation = super(ConnectivityStatementSerializer, self).to_representation(instance)
+        depth = self.context.get('depth', 0)
+
+        if depth < 1:
+            representation["forward_connection"] = KnowledgeStatementSerializer(
+                instance.forward_connection.all(),
+                many=True,
+                context={**self.context, 'depth': depth + 1}
+            ).data
+        return representation
+    
     class Meta(ConnectivityStatementSerializer.Meta):
         fields = (
             "id",
@@ -696,3 +708,4 @@ class KnowledgeStatementSerializer(ConnectivityStatementSerializer):
             "phenotype",
             "reference_uri"
         )
+        

--- a/backend/composer/api/serializers.py
+++ b/backend/composer/api/serializers.py
@@ -683,11 +683,6 @@ class ConnectivityStatementUpdateSerializer(ConnectivityStatementSerializer):
 
 class KnowledgeStatementSerializer(ConnectivityStatementSerializer):
     """Knowledge Statement"""
-    def to_representation(self, instance):
-        rep = super().to_representation(instance)
-        rep.pop('forward_connection', None)
-        return rep
-    
     class Meta(ConnectivityStatementSerializer.Meta):
         fields = (
             "id",

--- a/backend/composer/api/serializers.py
+++ b/backend/composer/api/serializers.py
@@ -683,6 +683,11 @@ class ConnectivityStatementUpdateSerializer(ConnectivityStatementSerializer):
 
 class KnowledgeStatementSerializer(ConnectivityStatementSerializer):
     """Knowledge Statement"""
+    def to_representation(self, instance):
+        rep = super().to_representation(instance)
+        rep.pop('forward_connection', None)
+        return rep
+    
     class Meta(ConnectivityStatementSerializer.Meta):
         fields = (
             "id",
@@ -694,4 +699,5 @@ class KnowledgeStatementSerializer(ConnectivityStatementSerializer):
             "apinatomy_model",
             "phenotype_id",
             "phenotype",
+            "reference_uri"
         )

--- a/backend/composer/apps.py
+++ b/backend/composer/apps.py
@@ -8,4 +8,5 @@ class ComposerConfig(AppConfig):
     def ready(self) -> None:
         # activate the signals
         from .signals import post_transition_callback
+        from .api import handlers  # noqa
         return super().ready()

--- a/frontend/src/apiclient/backend/api.ts
+++ b/frontend/src/apiclient/backend/api.ts
@@ -675,6 +675,73 @@ export interface DestinationSerializerDetails {
 
 
 /**
+ * Knowledge Statement
+ * @export
+ * @interface KnowledgeStatement
+ */
+export interface KnowledgeStatement {
+    /**
+     * 
+     * @type {number}
+     * @memberof KnowledgeStatement
+     */
+    'id': number | null;
+    /**
+     * 
+     * @type {number}
+     * @memberof KnowledgeStatement
+     */
+    'sentence_id'?: number;
+    /**
+     * 
+     * @type {Array<Specie>}
+     * @memberof KnowledgeStatement
+     */
+    'species'?: Array<Specie>;
+    /**
+     * 
+     * @type {Array<AnatomicalEntity>}
+     * @memberof KnowledgeStatement
+     */
+    'origins'?: Array<AnatomicalEntity>;
+    /**
+     * 
+     * @type {Array<ViaSerializerDetails>}
+     * @memberof KnowledgeStatement
+     */
+    'vias'?: Array<ViaSerializerDetails>;
+    /**
+     * 
+     * @type {Array<DestinationSerializerDetails>}
+     * @memberof KnowledgeStatement
+     */
+    'destinations'?: Array<DestinationSerializerDetails>;
+    /**
+     * 
+     * @type {string}
+     * @memberof KnowledgeStatement
+     */
+    'apinatomy_model'?: string | null;
+    /**
+     * 
+     * @type {number}
+     * @memberof KnowledgeStatement
+     */
+    'phenotype_id'?: number | null;
+    /**
+     * 
+     * @type {Phenotype}
+     * @memberof KnowledgeStatement
+     */
+    'phenotype': Phenotype;
+    /**
+     * 
+     * @type {string}
+     * @memberof KnowledgeStatement
+     */
+    'reference_uri'?: string | null;
+}
+/**
  * 
  * @export
  * @enum {string}
@@ -905,6 +972,37 @@ export interface PaginatedDestinationList {
      * @memberof PaginatedDestinationList
      */
     'results'?: Array<Destination>;
+}
+/**
+ * 
+ * @export
+ * @interface PaginatedKnowledgeStatementList
+ */
+export interface PaginatedKnowledgeStatementList {
+    /**
+     * 
+     * @type {number}
+     * @memberof PaginatedKnowledgeStatementList
+     */
+    'count'?: number;
+    /**
+     * 
+     * @type {string}
+     * @memberof PaginatedKnowledgeStatementList
+     */
+    'next'?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof PaginatedKnowledgeStatementList
+     */
+    'previous'?: string | null;
+    /**
+     * 
+     * @type {Array<KnowledgeStatement>}
+     * @memberof PaginatedKnowledgeStatementList
+     */
+    'results'?: Array<KnowledgeStatement>;
 }
 /**
  * 
@@ -6734,3 +6832,158 @@ export class MetacellAuthApi extends BaseAPI {
         return MetacellAuthApiFp(this.configuration).metacellAuthLogoutRetrieve(options).then((request) => request(this.axios, this.basePath));
     }
 }
+
+
+
+/**
+ * PublicApi - axios parameter creator
+ * @export
+ */
+export const PublicApiAxiosParamCreator = function (configuration?: Configuration) {
+    return {
+        /**
+         * KnowledgeStatement that only allows GET to get the list of ConnectivityStatements
+         * @param {Array<string>} [destinationUris] Multiple values may be separated by commas.
+         * @param {number} [limit] Number of results to return per page.
+         * @param {number} [offset] The initial index from which to return the results.
+         * @param {Array<string>} [originUris] Multiple values may be separated by commas.
+         * @param {Array<string>} [populationUris] Multiple values may be separated by commas.
+         * @param {Array<string>} [viaUris] Multiple values may be separated by commas.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        composerKnowledgeStatementList: async (destinationUris?: Array<string>, limit?: number, offset?: number, originUris?: Array<string>, populationUris?: Array<string>, viaUris?: Array<string>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/composer/knowledge-statement/`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication basicAuth required
+            // http basic authentication required
+            setBasicAuthToObject(localVarRequestOptions, configuration)
+
+            // authentication tokenAuth required
+            await setApiKeyToObject(localVarHeaderParameter, "Authorization", configuration)
+
+            // authentication cookieAuth required
+
+            if (destinationUris) {
+                localVarQueryParameter['destination_uris'] = destinationUris.join(COLLECTION_FORMATS.csv);
+            }
+
+            if (limit !== undefined) {
+                localVarQueryParameter['limit'] = limit;
+            }
+
+            if (offset !== undefined) {
+                localVarQueryParameter['offset'] = offset;
+            }
+
+            if (originUris) {
+                localVarQueryParameter['origin_uris'] = originUris.join(COLLECTION_FORMATS.csv);
+            }
+
+            if (populationUris) {
+                localVarQueryParameter['population_uris'] = populationUris.join(COLLECTION_FORMATS.csv);
+            }
+
+            if (viaUris) {
+                localVarQueryParameter['via_uris'] = viaUris.join(COLLECTION_FORMATS.csv);
+            }
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+    }
+};
+
+/**
+ * PublicApi - functional programming interface
+ * @export
+ */
+export const PublicApiFp = function(configuration?: Configuration) {
+    const localVarAxiosParamCreator = PublicApiAxiosParamCreator(configuration)
+    return {
+        /**
+         * KnowledgeStatement that only allows GET to get the list of ConnectivityStatements
+         * @param {Array<string>} [destinationUris] Multiple values may be separated by commas.
+         * @param {number} [limit] Number of results to return per page.
+         * @param {number} [offset] The initial index from which to return the results.
+         * @param {Array<string>} [originUris] Multiple values may be separated by commas.
+         * @param {Array<string>} [populationUris] Multiple values may be separated by commas.
+         * @param {Array<string>} [viaUris] Multiple values may be separated by commas.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async composerKnowledgeStatementList(destinationUris?: Array<string>, limit?: number, offset?: number, originUris?: Array<string>, populationUris?: Array<string>, viaUris?: Array<string>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedKnowledgeStatementList>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.composerKnowledgeStatementList(destinationUris, limit, offset, originUris, populationUris, viaUris, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+    }
+};
+
+/**
+ * PublicApi - factory interface
+ * @export
+ */
+export const PublicApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
+    const localVarFp = PublicApiFp(configuration)
+    return {
+        /**
+         * KnowledgeStatement that only allows GET to get the list of ConnectivityStatements
+         * @param {Array<string>} [destinationUris] Multiple values may be separated by commas.
+         * @param {number} [limit] Number of results to return per page.
+         * @param {number} [offset] The initial index from which to return the results.
+         * @param {Array<string>} [originUris] Multiple values may be separated by commas.
+         * @param {Array<string>} [populationUris] Multiple values may be separated by commas.
+         * @param {Array<string>} [viaUris] Multiple values may be separated by commas.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        composerKnowledgeStatementList(destinationUris?: Array<string>, limit?: number, offset?: number, originUris?: Array<string>, populationUris?: Array<string>, viaUris?: Array<string>, options?: any): AxiosPromise<PaginatedKnowledgeStatementList> {
+            return localVarFp.composerKnowledgeStatementList(destinationUris, limit, offset, originUris, populationUris, viaUris, options).then((request) => request(axios, basePath));
+        },
+    };
+};
+
+/**
+ * PublicApi - object-oriented interface
+ * @export
+ * @class PublicApi
+ * @extends {BaseAPI}
+ */
+export class PublicApi extends BaseAPI {
+    /**
+     * KnowledgeStatement that only allows GET to get the list of ConnectivityStatements
+     * @param {Array<string>} [destinationUris] Multiple values may be separated by commas.
+     * @param {number} [limit] Number of results to return per page.
+     * @param {number} [offset] The initial index from which to return the results.
+     * @param {Array<string>} [originUris] Multiple values may be separated by commas.
+     * @param {Array<string>} [populationUris] Multiple values may be separated by commas.
+     * @param {Array<string>} [viaUris] Multiple values may be separated by commas.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof PublicApi
+     */
+    public composerKnowledgeStatementList(destinationUris?: Array<string>, limit?: number, offset?: number, originUris?: Array<string>, populationUris?: Array<string>, viaUris?: Array<string>, options?: AxiosRequestConfig) {
+        return PublicApiFp(this.configuration).composerKnowledgeStatementList(destinationUris, limit, offset, originUris, populationUris, viaUris, options).then((request) => request(this.axios, this.basePath));
+    }
+}
+
+
+

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -756,6 +756,73 @@ paths:
                 type: object
                 additionalProperties: {}
           description: ''
+  /api/composer/knowledge-statement/:
+    get:
+      operationId: composer_knowledge_statement_list
+      description: KnowledgeStatement that only allows GET to get the list of ConnectivityStatements
+      parameters:
+      - in: query
+        name: destination_uris
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      - in: query
+        name: origin_uris
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: population_uris
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: via_uris
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      tags:
+      - public
+      security:
+      - tokenAuth: []
+      - basicAuth: []
+      - cookieAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedKnowledgeStatementList'
+          description: ''
   /api/composer/note/:
     get:
       operationId: composer_note_list
@@ -2191,6 +2258,51 @@ components:
       - connectivity_statement_id
       - from_entities
       - id
+    KnowledgeStatement:
+      type: object
+      description: Knowledge Statement
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          nullable: true
+        sentence_id:
+          type: integer
+        species:
+          type: array
+          items:
+            $ref: '#/components/schemas/Specie'
+        origins:
+          type: array
+          items:
+            $ref: '#/components/schemas/AnatomicalEntity'
+        vias:
+          type: array
+          items:
+            $ref: '#/components/schemas/ViaSerializerDetails'
+        destinations:
+          type: array
+          items:
+            $ref: '#/components/schemas/DestinationSerializerDetails'
+        apinatomy_model:
+          type: string
+          nullable: true
+          maxLength: 200
+        phenotype_id:
+          type: integer
+          nullable: true
+        phenotype:
+          allOf:
+          - $ref: '#/components/schemas/Phenotype'
+          readOnly: true
+        reference_uri:
+          type: string
+          format: uri
+          nullable: true
+          maxLength: 200
+      required:
+      - id
+      - phenotype
     LateralityEnum:
       enum:
       - RIGHT
@@ -2320,6 +2432,26 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Destination'
+    PaginatedKnowledgeStatementList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/KnowledgeStatement'
     PaginatedNoteList:
       type: object
       properties:


### PR DESCRIPTION
jira Link - update on -> https://metacell.atlassian.net/browse/ESCKAN-35

- add reference_uri to KnowledgeStatement endpoint response 
- Corrected the serializer to_representation for KS-serializer - `super(ConnectivityStatementSerializer, self).to_representation(instance)`
- Added CORS to `/api/composer/knowledge-statement/` using [django-cors-header's signals](https://github.com/adamchainz/django-cors-headers?tab=readme-ov-file#signals).
