### PR TITLE
ESCKAN-35 add cors requirement txt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,6 +17,7 @@ drf-react-template-framework==0.0.17
 aiohttp==3.8.3
 crossref-commons==0.0.7
 neurondm==0.1.8
+django-cors-headers==4.3.1
 
 django-debug-toolbar
 django-sslserver # ssl dev server, for testing orcid social login


### PR DESCRIPTION
Update requirements to add django-cors-headers==4.3.1
