### PR TITLE
Feature/esckan 35 - add additional fields to the public KS endpoint

### DIFF
--- a/backend/composer/api/serializers.py
+++ b/backend/composer/api/serializers.py
@@ -706,6 +706,15 @@ class KnowledgeStatementSerializer(ConnectivityStatementSerializer):
             "apinatomy_model",
             "phenotype_id",
             "phenotype",
-            "reference_uri"
+            "reference_uri",
+            "provenances",
+            "knowledge_statement",
+            "journey",
+            "laterality",
+            "projection",
+            "circuit_type",
+            "sex",
+            "apinatomy_model",
+            "statement_preview",
         )
         


### PR DESCRIPTION

Add additional fields to the public KS endpoint. Newly added fields are -             
            "provenances",
            "knowledge_statement",
            "journey",
            "laterality",
            "projection",
            "circuit_type",
            "sex",
            "apinatomy_model",
            "statement_preview",



Video demo:

https://github.com/MetaCell/sckan-composer/assets/59233227/6f833aca-5962-486e-b31f-f5aa5129d705


