### PR TITLE
Feature/esckan 58

### DIFF
--- a/backend/composer/api/serializers.py
+++ b/backend/composer/api/serializers.py
@@ -597,6 +597,10 @@ class ConnectivityStatementSerializer(BaseConnectivityStatementSerializer):
                 many=True,
                 context={**self.context, 'depth': depth + 1}
             ).data
+
+        if 'journey' in self.context:
+            del self.context['journey']
+
         return representation
 
     def update(self, instance, validated_data):
@@ -683,6 +687,7 @@ class ConnectivityStatementUpdateSerializer(ConnectivityStatementSerializer):
 
 class KnowledgeStatementSerializer(ConnectivityStatementSerializer):
     """Knowledge Statement"""
+
     def to_representation(self, instance):
         representation = super(ConnectivityStatementSerializer, self).to_representation(instance)
         depth = self.context.get('depth', 0)
@@ -693,8 +698,12 @@ class KnowledgeStatementSerializer(ConnectivityStatementSerializer):
                 many=True,
                 context={**self.context, 'depth': depth + 1}
             ).data
+
+        if 'journey' in self.context:
+            del self.context['journey']
+
         return representation
-    
+
     class Meta(ConnectivityStatementSerializer.Meta):
         fields = (
             "id",
@@ -717,4 +726,3 @@ class KnowledgeStatementSerializer(ConnectivityStatementSerializer):
             "apinatomy_model",
             "statement_preview",
         )
-        

--- a/backend/composer/api/views.py
+++ b/backend/composer/api/views.py
@@ -313,7 +313,6 @@ class ConnectivityStatementViewSet(
     filterset_class = ConnectivityStatementFilter
     service = ConnectivityStatementStateService
 
-
     def get_serializer_class(self):
         if self.action == 'list':
             return BaseConnectivityStatementSerializer
@@ -371,7 +370,6 @@ class KnowledgeStatementViewSet(
 
     def get_serializer_class(self):
         return KnowledgeStatementSerializer
-
 
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)


### PR DESCRIPTION
Closes https://metacell.atlassian.net/browse/ESCKAN-58

- Updates KnowledgeStatement serializer (and ConnectivityStatement serializer) to remove memoized 'journey' after representation is calculated.

For context the journey is being memorized per instance because it's a calculated property which is somewhat expensive to calculate and it's used both in the journey attribute itself and in the statement preview. 
The problem fixed with this change was not present in Composer because we only used the ConnectivityStatement serializer for individual serializations (not on 'list' actions).

The fix should have no impact in composer.

![image](https://github.com/MetaCell/sckan-composer/assets/19196034/c950e7e2-cd7d-4f0b-b328-ad112fcf2b1d)


https://github.com/MetaCell/sckan-composer/assets/19196034/7f1d3593-7ef2-4458-b4e1-06956e656330

