### PR TITLE
Feature/csckan-293 - Front end Projection Phenotypes do not reflect Projection phenotypes specified in Admin table

### DIFF
--- a/backend/composer/admin.py
+++ b/backend/composer/admin.py
@@ -194,6 +194,7 @@ class ConnectivityStatementAdmin(
         "sentence__pmcid",
         "knowledge_statement",
     )
+    exclude = ("projection",)
 
     fieldsets = ()
 

--- a/backend/composer/api/serializers.py
+++ b/backend/composer/api/serializers.py
@@ -11,6 +11,7 @@ from ..enums import SentenceState, CSState
 from ..models import (
     AnatomicalEntity,
     Phenotype,
+    ProjectionPhenotype,
     Sex,
     ConnectivityStatement,
     Provenance,
@@ -176,6 +177,14 @@ class PhenotypeSerializer(UniqueFieldsMixin, serializers.ModelSerializer):
 
     class Meta:
         model = Phenotype
+        fields = ("id", "name")
+
+
+class ProjectionPhenotypeSerializer(UniqueFieldsMixin, serializers.ModelSerializer):
+    """Phenotype"""
+
+    class Meta:
+        model = ProjectionPhenotype
         fields = ("id", "name")
 
 
@@ -368,6 +377,9 @@ class SentenceConnectivityStatement(serializers.ModelSerializer):
     phenotype_id = serializers.IntegerField(
         required=False, default=None, allow_null=True
     )
+    projection_phenotype_id = serializers.IntegerField(
+        required=False, default=None, allow_null=True
+    )
     provenances = ProvenanceSerializer(
         source="provenance_set", many=True, read_only=False
     )
@@ -375,6 +387,7 @@ class SentenceConnectivityStatement(serializers.ModelSerializer):
     species = SpecieSerializer(many=True, read_only=True)
     owner = UserSerializer(required=False, read_only=True)
     phenotype = PhenotypeSerializer(required=False, read_only=True)
+    projection_phenotype = ProjectionPhenotypeSerializer(required=False, read_only=True)
 
     class Meta:
         model = ConnectivityStatement
@@ -385,6 +398,8 @@ class SentenceConnectivityStatement(serializers.ModelSerializer):
             "provenances",
             "phenotype_id",
             "phenotype",
+            "projection_phenotype",
+            "projection_phenotype_id",
             "laterality",
             "projection",
             "circuit_type",
@@ -403,6 +418,8 @@ class SentenceConnectivityStatement(serializers.ModelSerializer):
             "provenances",
             "phenotype_id",
             "phenotype",
+            "projection_phenotype",
+            "projection_phenotype_id",
             "laterality",
             "projection",
             "circuit_type",
@@ -506,6 +523,7 @@ class ConnectivityStatementSerializer(BaseConnectivityStatementSerializer):
 
     sentence_id = serializers.IntegerField(required=False)
     phenotype_id = serializers.IntegerField(required=False, allow_null=True)
+    projection_phenotype_id = serializers.IntegerField(required=False, allow_null=True)
     sex_id = serializers.IntegerField(required=False, allow_null=True)
     species = SpecieSerializer(many=True, read_only=False, required=False)
     provenances = ProvenanceSerializer(source="provenance_set", many=True, read_only=False, required=False)
@@ -513,6 +531,7 @@ class ConnectivityStatementSerializer(BaseConnectivityStatementSerializer):
     vias = ViaSerializerDetails(source="via_set", many=True, read_only=False, required=False)
     destinations = DestinationSerializerDetails(many=True, required=False)
     phenotype = PhenotypeSerializer(required=False, read_only=True)
+    projection_phenotype = ProjectionPhenotypeSerializer(required=False, read_only=True)
     sex = SexSerializer(required=False, read_only=True)
     sentence = SentenceSerializer(required=False, read_only=True)
     forward_connection = serializers.PrimaryKeyRelatedField(
@@ -553,7 +572,8 @@ class ConnectivityStatementSerializer(BaseConnectivityStatementSerializer):
             origins = ""
 
         circuit_type = instance.get_circuit_type_display() if instance.circuit_type else None
-        projection = instance.get_projection_display() if instance.projection else None
+        # projection = instance.get_projection_display() if instance.projection else None
+        projection_phenotype = str(instance.projection_phenotype) if instance.projection_phenotype else ''
 
         laterality_description = instance.get_laterality_description()
 
@@ -567,8 +587,8 @@ class ConnectivityStatementSerializer(BaseConnectivityStatementSerializer):
             statement = f"A {phenotype.lower()} connection goes {journey_sentence}.\n"
 
         statement += f"This "
-        if projection:
-            statement += f"{projection.lower()} "
+        if projection_phenotype:
+            statement += f"{projection_phenotype.lower()} "
         if circuit_type:
             statement += f"{circuit_type.lower()} "
 
@@ -628,6 +648,8 @@ class ConnectivityStatementSerializer(BaseConnectivityStatementSerializer):
             "destinations",
             "phenotype_id",
             "phenotype",
+            "projection_phenotype",
+            "projection_phenotype_id",
             "journey",
             "laterality",
             "projection",
@@ -668,6 +690,8 @@ class ConnectivityStatementUpdateSerializer(ConnectivityStatementSerializer):
             "destinations",
             "phenotype_id",
             "phenotype",
+            "projection_phenotype",
+            "projection_phenotype_id",
             "journey",
             "laterality",
             "projection",

--- a/backend/composer/api/serializers.py
+++ b/backend/composer/api/serializers.py
@@ -572,7 +572,6 @@ class ConnectivityStatementSerializer(BaseConnectivityStatementSerializer):
             origins = ""
 
         circuit_type = instance.get_circuit_type_display() if instance.circuit_type else None
-        # projection = instance.get_projection_display() if instance.projection else None
         projection_phenotype = str(instance.projection_phenotype) if instance.projection_phenotype else ''
 
         laterality_description = instance.get_laterality_description()

--- a/backend/composer/api/urls.py
+++ b/backend/composer/api/urls.py
@@ -4,6 +4,7 @@ from rest_framework.routers import DefaultRouter
 from .views import (
     AnatomicalEntityViewSet,
     PhenotypeViewSet,
+	ProjectionPhenotypeViewSet,
     ConnectivityStatementViewSet,
 	KnowledgeStatementViewSet,
     jsonschemas,
@@ -22,6 +23,7 @@ router.register(
     r"anatomical-entity", AnatomicalEntityViewSet, basename="anatomical-entity"
 )
 router.register(r"phenotype", PhenotypeViewSet, basename="phenotype")
+router.register(r"projection", ProjectionPhenotypeViewSet, basename="projection-phenotype")
 router.register(r"sex", SexViewSet, basename="sex")
 router.register(
     r"connectivity-statement",

--- a/backend/composer/api/views.py
+++ b/backend/composer/api/views.py
@@ -28,6 +28,7 @@ from .filtersets import (
 from .serializers import (
     AnatomicalEntitySerializer,
     PhenotypeSerializer,
+    ProjectionPhenotypeSerializer,
     ConnectivityStatementSerializer,
     KnowledgeStatementSerializer,
     NoteSerializer,
@@ -43,6 +44,7 @@ from .permissions import IsStaffUserIfExportedStateInConnectivityStatement
 from ..models import (
     AnatomicalEntity,
     Phenotype,
+    ProjectionPhenotype,
     ConnectivityStatement,
     Note,
     Profile,
@@ -261,6 +263,17 @@ class PhenotypeViewSet(viewsets.ReadOnlyModelViewSet):
 
     queryset = Phenotype.objects.all()
     serializer_class = PhenotypeSerializer
+    permission_classes = [
+        permissions.IsAuthenticatedOrReadOnly,
+    ]
+
+
+class ProjectionPhenotypeViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    Projection Phenotype
+    """
+    queryset = ProjectionPhenotype.objects.all()
+    serializer_class = ProjectionPhenotypeSerializer
     permission_classes = [
         permissions.IsAuthenticatedOrReadOnly,
     ]

--- a/backend/composer/models.py
+++ b/backend/composer/models.py
@@ -668,11 +668,6 @@ class ConnectivityStatement(models.Model):
                 check=Q(circuit_type__in=[c[0] for c in CircuitType.choices]),
                 name="circuit_type_valid",
             ),
-
-            models.CheckConstraint(
-                check=Q(projection__in=[p[0] for p in Projection.choices]),
-                name="projection_valid",
-            ),
         ]
 
 

--- a/frontend/src/apiclient/backend/api.ts
+++ b/frontend/src/apiclient/backend/api.ts
@@ -308,6 +308,18 @@ export interface ConnectivityStatement {
     'phenotype': Phenotype;
     /**
      * 
+     * @type {ProjectionPhenotype}
+     * @memberof ConnectivityStatement
+     */
+    'projection_phenotype': ProjectionPhenotype;
+    /**
+     * 
+     * @type {number}
+     * @memberof ConnectivityStatement
+     */
+    'projection_phenotype_id'?: number | null;
+    /**
+     * 
      * @type {string}
      * @memberof ConnectivityStatement
      */
@@ -505,6 +517,18 @@ export interface ConnectivityStatementUpdate {
      * @memberof ConnectivityStatementUpdate
      */
     'phenotype': Phenotype;
+    /**
+     * 
+     * @type {ProjectionPhenotype}
+     * @memberof ConnectivityStatementUpdate
+     */
+    'projection_phenotype': ProjectionPhenotype;
+    /**
+     * 
+     * @type {number}
+     * @memberof ConnectivityStatementUpdate
+     */
+    'projection_phenotype_id'?: number | null;
     /**
      * 
      * @type {string}
@@ -740,6 +764,54 @@ export interface KnowledgeStatement {
      * @memberof KnowledgeStatement
      */
     'reference_uri'?: string | null;
+    /**
+     * 
+     * @type {Array<Provenance>}
+     * @memberof KnowledgeStatement
+     */
+    'provenances'?: Array<Provenance>;
+    /**
+     * 
+     * @type {string}
+     * @memberof KnowledgeStatement
+     */
+    'knowledge_statement'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof KnowledgeStatement
+     */
+    'journey': string;
+    /**
+     * 
+     * @type {ConnectivityStatementLaterality}
+     * @memberof KnowledgeStatement
+     */
+    'laterality'?: ConnectivityStatementLaterality | null;
+    /**
+     * 
+     * @type {ConnectivityStatementProjection}
+     * @memberof KnowledgeStatement
+     */
+    'projection'?: ConnectivityStatementProjection | null;
+    /**
+     * 
+     * @type {ConnectivityStatementCircuitType}
+     * @memberof KnowledgeStatement
+     */
+    'circuit_type'?: ConnectivityStatementCircuitType | null;
+    /**
+     * 
+     * @type {Sex}
+     * @memberof KnowledgeStatement
+     */
+    'sex': Sex;
+    /**
+     * 
+     * @type {string}
+     * @memberof KnowledgeStatement
+     */
+    'statement_preview': string;
 }
 /**
  * 
@@ -1069,6 +1141,37 @@ export interface PaginatedPhenotypeList {
 /**
  * 
  * @export
+ * @interface PaginatedProjectionPhenotypeList
+ */
+export interface PaginatedProjectionPhenotypeList {
+    /**
+     * 
+     * @type {number}
+     * @memberof PaginatedProjectionPhenotypeList
+     */
+    'count'?: number;
+    /**
+     * 
+     * @type {string}
+     * @memberof PaginatedProjectionPhenotypeList
+     */
+    'next'?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof PaginatedProjectionPhenotypeList
+     */
+    'previous'?: string | null;
+    /**
+     * 
+     * @type {Array<ProjectionPhenotype>}
+     * @memberof PaginatedProjectionPhenotypeList
+     */
+    'results'?: Array<ProjectionPhenotype>;
+}
+/**
+ * 
+ * @export
  * @interface PaginatedSentenceList
  */
 export interface PaginatedSentenceList {
@@ -1317,6 +1420,18 @@ export interface PatchedConnectivityStatementUpdate {
      * @memberof PatchedConnectivityStatementUpdate
      */
     'phenotype'?: Phenotype;
+    /**
+     * 
+     * @type {ProjectionPhenotype}
+     * @memberof PatchedConnectivityStatementUpdate
+     */
+    'projection_phenotype'?: ProjectionPhenotype;
+    /**
+     * 
+     * @type {number}
+     * @memberof PatchedConnectivityStatementUpdate
+     */
+    'projection_phenotype_id'?: number | null;
     /**
      * 
      * @type {string}
@@ -1716,6 +1831,31 @@ export type ProjectionEnum = typeof ProjectionEnum[keyof typeof ProjectionEnum];
 
 
 /**
+ * Phenotype
+ * @export
+ * @interface ProjectionPhenotype
+ */
+export interface ProjectionPhenotype {
+    /**
+     * 
+     * @type {number}
+     * @memberof ProjectionPhenotype
+     */
+    'id': number;
+    /**
+     * 
+     * @type {string}
+     * @memberof ProjectionPhenotype
+     */
+    'name': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof ProjectionPhenotype
+     */
+    'ontology_uri': string;
+}
+/**
  * Provenance
  * @export
  * @interface Provenance
@@ -1953,6 +2093,18 @@ export interface SentenceConnectivityStatement {
      * @memberof SentenceConnectivityStatement
      */
     'phenotype': Phenotype;
+    /**
+     * 
+     * @type {ProjectionPhenotype}
+     * @memberof SentenceConnectivityStatement
+     */
+    'projection_phenotype': ProjectionPhenotype;
+    /**
+     * 
+     * @type {number}
+     * @memberof SentenceConnectivityStatement
+     */
+    'projection_phenotype_id'?: number | null;
     /**
      * 
      * @type {LateralityEnum}
@@ -3852,6 +4004,96 @@ export const ComposerApiAxiosParamCreator = function (configuration?: Configurat
             };
         },
         /**
+         * Projection Phenotype
+         * @param {number} [limit] Number of results to return per page.
+         * @param {number} [offset] The initial index from which to return the results.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        composerProjectionList: async (limit?: number, offset?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/composer/projection/`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication basicAuth required
+            // http basic authentication required
+            setBasicAuthToObject(localVarRequestOptions, configuration)
+
+            // authentication tokenAuth required
+            await setApiKeyToObject(localVarHeaderParameter, "Authorization", configuration)
+
+            // authentication cookieAuth required
+
+            if (limit !== undefined) {
+                localVarQueryParameter['limit'] = limit;
+            }
+
+            if (offset !== undefined) {
+                localVarQueryParameter['offset'] = offset;
+            }
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Projection Phenotype
+         * @param {number} id A unique integer value identifying this projection phenotype.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        composerProjectionRetrieve: async (id: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'id' is not null or undefined
+            assertParamExists('composerProjectionRetrieve', 'id', id)
+            const localVarPath = `/api/composer/projection/{id}/`
+                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication basicAuth required
+            // http basic authentication required
+            setBasicAuthToObject(localVarRequestOptions, configuration)
+
+            // authentication tokenAuth required
+            await setApiKeyToObject(localVarHeaderParameter, "Authorization", configuration)
+
+            // authentication cookieAuth required
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * Sentence
          * @param {number} id A unique integer value identifying this sentence.
          * @param {number} tagId 
@@ -5187,6 +5429,27 @@ export const ComposerApiFp = function(configuration?: Configuration) {
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
+         * Projection Phenotype
+         * @param {number} [limit] Number of results to return per page.
+         * @param {number} [offset] The initial index from which to return the results.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async composerProjectionList(limit?: number, offset?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedProjectionPhenotypeList>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.composerProjectionList(limit, offset, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * Projection Phenotype
+         * @param {number} id A unique integer value identifying this projection phenotype.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async composerProjectionRetrieve(id: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ProjectionPhenotype>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.composerProjectionRetrieve(id, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
          * Sentence
          * @param {number} id A unique integer value identifying this sentence.
          * @param {number} tagId 
@@ -5755,6 +6018,25 @@ export const ComposerApiFactory = function (configuration?: Configuration, baseP
          */
         composerProfileMyRetrieve(options?: any): AxiosPromise<Profile> {
             return localVarFp.composerProfileMyRetrieve(options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Projection Phenotype
+         * @param {number} [limit] Number of results to return per page.
+         * @param {number} [offset] The initial index from which to return the results.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        composerProjectionList(limit?: number, offset?: number, options?: any): AxiosPromise<PaginatedProjectionPhenotypeList> {
+            return localVarFp.composerProjectionList(limit, offset, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Projection Phenotype
+         * @param {number} id A unique integer value identifying this projection phenotype.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        composerProjectionRetrieve(id: number, options?: any): AxiosPromise<ProjectionPhenotype> {
+            return localVarFp.composerProjectionRetrieve(id, options).then((request) => request(axios, basePath));
         },
         /**
          * Sentence
@@ -6372,6 +6654,29 @@ export class ComposerApi extends BaseAPI {
      */
     public composerProfileMyRetrieve(options?: AxiosRequestConfig) {
         return ComposerApiFp(this.configuration).composerProfileMyRetrieve(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Projection Phenotype
+     * @param {number} [limit] Number of results to return per page.
+     * @param {number} [offset] The initial index from which to return the results.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ComposerApi
+     */
+    public composerProjectionList(limit?: number, offset?: number, options?: AxiosRequestConfig) {
+        return ComposerApiFp(this.configuration).composerProjectionList(limit, offset, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Projection Phenotype
+     * @param {number} id A unique integer value identifying this projection phenotype.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ComposerApi
+     */
+    public composerProjectionRetrieve(id: number, options?: AxiosRequestConfig) {
+        return ComposerApiFp(this.configuration).composerProjectionRetrieve(id, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/frontend/src/components/Forms/StatementForm.tsx
+++ b/frontend/src/components/Forms/StatementForm.tsx
@@ -44,6 +44,7 @@ import {
 } from "../../apiclient/backend";
 import { CustomFooter } from "../Widgets/HoveredOptionContent";
 import { StatementStateChip } from "../Widgets/StateChip";
+import { projections } from "../../services/ProjectionService";
 
 const StatementForm = (props: any) => {
   const { uiFields, statement, refreshStatement, isDisabled } = props;
@@ -76,15 +77,22 @@ const StatementForm = (props: any) => {
     },
   };
 
-  copiedUISchema.projection = {
+
+  copiedUISchema.projection_phenotype_id = {
     "ui:widget": "CustomSingleSelect",
     "ui:options": {
       isDisabled,
       label: "Projection",
       classNames: "col-xs-12 col-md-6",
       placeholder: "Enter Projection",
+      data: projections.getProjections().map((row: any) => ({
+        label: row.name,
+        value: row.id,
+      })),
     },
+    value: statement?.projection_phenotype_id ?? "",
   };
+
 
   copiedUISchema.apinatomy_model = {
     "ui:widget": "CustomTextField",
@@ -121,6 +129,8 @@ const StatementForm = (props: any) => {
     },
     value: statement?.phenotype_id ?? "",
   };
+
+
 
   copiedUISchema.knowledge_statement = {
     "ui:widget": "CustomTextArea",
@@ -658,6 +668,7 @@ const StatementForm = (props: any) => {
     },
   };
 
+
   // Add null option to the fields which have null type in dropdown.
   Object.keys(copiedSchema.properties).forEach((key) => {
     if (copiedSchema.properties[key].type.includes("null") && copiedSchema.properties[key]?.enum && copiedSchema.properties[key]?.enumNames) {
@@ -701,7 +712,7 @@ const StatementForm = (props: any) => {
         "sex_id",
         "laterality",
         "circuit_type",
-        "projection",
+        "projection_phenotype_id",
       ]}
       {...props}
     />

--- a/frontend/src/components/TriageStatementSection/StatementDetailsAccordion.tsx
+++ b/frontend/src/components/TriageStatementSection/StatementDetailsAccordion.tsx
@@ -67,7 +67,7 @@ const StatementDetailsAccordion = (props: any) => {
             "apinatomy_model",
             "circuit_type",
             "laterality",
-            "projection",
+            "projection_phenotype_id",
             "phenotype_id",
             "additional_information"
           ]}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -9,6 +9,7 @@ import { tags } from "./services/TagService";
 import { species } from "./services/SpecieService";
 import { sexes } from "./services/SexService";
 import { phenotypes } from "./services/PhenotypeService";
+import { projections } from "./services/ProjectionService";
 import { Provider } from "react-redux";
 import { store } from "./redux/store";
 
@@ -22,11 +23,13 @@ doLogin().then(() => {
       species.setSpecieList().then(() => {
         sexes.setSexes().then(() => {
           phenotypes.setPhenotypes().then(() => {
-            root.render(
+            projections.setProjections().then(() => {
+              root.render(
                 <Provider store={store}>
                   <App />
                 </Provider>
-            );
+              );
+            });
           });
         });
       });

--- a/frontend/src/services/ProjectionService.tsx
+++ b/frontend/src/services/ProjectionService.tsx
@@ -1,0 +1,19 @@
+import { composerApi } from "./apis";
+import { ProjectionPhenotype } from "../apiclient/backend";
+
+export let projections = (function () {
+	let projectionsList: ProjectionPhenotype[] = [];
+
+	return {
+		// public interface
+		setProjections: async function () {
+			return composerApi.composerProjectionList(undefined).then((resp: any) => {
+				projectionsList = resp.data.results;
+			});
+		},
+		getProjections: function (): ProjectionPhenotype[] {
+			return projectionsList;
+		},
+	};
+})();
+

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1135,6 +1135,62 @@ paths:
               schema:
                 $ref: '#/components/schemas/Profile'
           description: ''
+  /api/composer/projection/:
+    get:
+      operationId: composer_projection_list
+      description: Projection Phenotype
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - composer
+      security:
+      - tokenAuth: []
+      - basicAuth: []
+      - cookieAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedProjectionPhenotypeList'
+          description: ''
+  /api/composer/projection/{id}/:
+    get:
+      operationId: composer_projection_retrieve
+      description: Projection Phenotype
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this projection phenotype.
+        required: true
+      tags:
+      - composer
+      security:
+      - tokenAuth: []
+      - basicAuth: []
+      - cookieAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectionPhenotype'
+          description: ''
   /api/composer/sentence/:
     get:
       operationId: composer_sentence_list
@@ -2006,6 +2062,13 @@ components:
           allOf:
           - $ref: '#/components/schemas/Phenotype'
           readOnly: true
+        projection_phenotype:
+          allOf:
+          - $ref: '#/components/schemas/ProjectionPhenotype'
+          readOnly: true
+        projection_phenotype_id:
+          type: integer
+          nullable: true
         journey:
           type: string
           readOnly: true
@@ -2072,6 +2135,7 @@ components:
       - modified_date
       - owner
       - phenotype
+      - projection_phenotype
       - sentence
       - sex
       - state
@@ -2136,6 +2200,13 @@ components:
           allOf:
           - $ref: '#/components/schemas/Phenotype'
           readOnly: true
+        projection_phenotype:
+          allOf:
+          - $ref: '#/components/schemas/ProjectionPhenotype'
+          readOnly: true
+        projection_phenotype_id:
+          type: integer
+          nullable: true
         journey:
           type: string
           readOnly: true
@@ -2203,6 +2274,7 @@ components:
       - origins
       - owner
       - phenotype
+      - projection_phenotype
       - sentence
       - sex
       - statement_preview
@@ -2300,9 +2372,46 @@ components:
           format: uri
           nullable: true
           maxLength: 200
+        provenances:
+          type: array
+          items:
+            $ref: '#/components/schemas/Provenance'
+        knowledge_statement:
+          type: string
+        journey:
+          type: string
+          readOnly: true
+        laterality:
+          nullable: true
+          oneOf:
+          - $ref: '#/components/schemas/LateralityEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+          - $ref: '#/components/schemas/NullEnum'
+        projection:
+          nullable: true
+          oneOf:
+          - $ref: '#/components/schemas/ProjectionEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+          - $ref: '#/components/schemas/NullEnum'
+        circuit_type:
+          nullable: true
+          oneOf:
+          - $ref: '#/components/schemas/CircuitTypeEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+          - $ref: '#/components/schemas/NullEnum'
+        sex:
+          allOf:
+          - $ref: '#/components/schemas/Sex'
+          readOnly: true
+        statement_preview:
+          type: string
+          readOnly: true
       required:
       - id
+      - journey
       - phenotype
+      - sex
+      - statement_preview
     LateralityEnum:
       enum:
       - RIGHT
@@ -2492,6 +2601,26 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Phenotype'
+    PaginatedProjectionPhenotypeList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProjectionPhenotype'
     PaginatedSentenceList:
       type: object
       properties:
@@ -2651,6 +2780,13 @@ components:
           allOf:
           - $ref: '#/components/schemas/Phenotype'
           readOnly: true
+        projection_phenotype:
+          allOf:
+          - $ref: '#/components/schemas/ProjectionPhenotype'
+          readOnly: true
+        projection_phenotype_id:
+          type: integer
+          nullable: true
         journey:
           type: string
           readOnly: true
@@ -2875,6 +3011,24 @@ components:
       - CONTRAT
       - BI
       type: string
+    ProjectionPhenotype:
+      type: object
+      description: Phenotype
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 200
+        ontology_uri:
+          type: string
+          format: uri
+          maxLength: 200
+      required:
+      - id
+      - name
+      - ontology_uri
     Provenance:
       type: object
       description: Provenance
@@ -3030,6 +3184,13 @@ components:
           allOf:
           - $ref: '#/components/schemas/Phenotype'
           readOnly: true
+        projection_phenotype:
+          allOf:
+          - $ref: '#/components/schemas/ProjectionPhenotype'
+          readOnly: true
+        projection_phenotype_id:
+          type: integer
+          nullable: true
         laterality:
           readOnly: true
           nullable: true
@@ -3085,6 +3246,7 @@ components:
       - owner
       - phenotype
       - projection
+      - projection_phenotype
       - provenances
       - sentence_id
       - sex


### PR DESCRIPTION
Jira ticket - [SCKAN-293](https://metacell.atlassian.net/browse/SCKAN-293)

Task description:
1. Update serializer, viewset, and router - to avail ProjectionPhenotype.
2. Generate the openapi spec.
3. Replace projection phenotype instead of projection (from enum) in the FE 
4. remove projection from admin - so user can only add projection phenotype in the admin panel.

Video demo

https://github.com/MetaCell/sckan-composer/assets/59233227/01188665-82a4-45ce-a68b-ac0633e13ec7


[SCKAN-293]: https://metacell.atlassian.net/browse/SCKAN-293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ