### PR TITLE
Feature/esckan-65 - get entities (origin, destination, vias) in the journey as part of serializer export

### DIFF
--- a/backend/composer/api/serializers.py
+++ b/backend/composer/api/serializers.py
@@ -516,6 +516,7 @@ class ConnectivityStatementSerializer(BaseConnectivityStatementSerializer):
     )
     available_transitions = serializers.SerializerMethodField()
     journey = serializers.SerializerMethodField()
+    entities_journey = serializers.SerializerMethodField()    
     statement_preview = serializers.SerializerMethodField()
     errors = serializers.SerializerMethodField()
 
@@ -528,6 +529,10 @@ class ConnectivityStatementSerializer(BaseConnectivityStatementSerializer):
         if 'journey' not in self.context:
             self.context['journey'] = instance.get_journey()
         return self.context['journey']
+    
+    def get_entities_journey(self, instance):
+        self.context['entities_journey'] = instance.get_entities_journey()
+        return self.context['entities_journey']
 
     def get_statement_preview(self, instance):
         if 'journey' not in self.context:
@@ -630,6 +635,7 @@ class ConnectivityStatementSerializer(BaseConnectivityStatementSerializer):
             "projection_phenotype",
             "projection_phenotype_id",
             "journey",
+            "entities_journey",
             "laterality",
             "projection",
             "circuit_type",
@@ -722,6 +728,7 @@ class KnowledgeStatementSerializer(ConnectivityStatementSerializer):
             "provenances",
             "knowledge_statement",
             "journey",
+            "entities_journey",
             "laterality",
             "projection",
             "circuit_type",

--- a/backend/composer/models.py
+++ b/backend/composer/models.py
@@ -21,7 +21,7 @@ from .enums import (
     ViaType,
     Projection,
 )
-from .services.graph_service import compile_journey, compile_entities_name
+from .services.graph_service import compile_journey
 from .utils import doi_uri, pmcid_uri, pmid_uri, create_reference_uri
 
 

--- a/backend/composer/models.py
+++ b/backend/composer/models.py
@@ -21,7 +21,7 @@ from .enums import (
     ViaType,
     Projection,
 )
-from .services.graph_service import compile_journey
+from .services.graph_service import compile_journey, compile_entities_name
 from .utils import doi_uri, pmcid_uri, pmid_uri, create_reference_uri
 
 
@@ -663,7 +663,11 @@ class ConnectivityStatement(models.Model):
             return set(self.via_set.get(order=via_order - 1).anatomical_entities.all())
 
     def get_journey(self):
-        return compile_journey(self)
+        return compile_journey(self)['journey']
+    
+    def get_entities_journey(self):
+        entities_journey = compile_journey(self)['entities']
+        return entities_journey
 
     def get_laterality_description(self):
         laterality_map = {

--- a/backend/composer/services/graph_service.py
+++ b/backend/composer/services/graph_service.py
@@ -88,7 +88,7 @@ def consolidate_paths(paths):
 
         paths = consolidated + [paths[i] for i in range(len(paths)) if i not in used_indices]
 
-    return [[((node[0].replace(JOURNEY_DELIMITER, ' or '), node[1]) if (
+    return paths, [[((node[0].replace(JOURNEY_DELIMITER, ' or '), node[1]) if (
             node[1] == 0 or path.index(node) == len(path) - 1) else (
         node[0].replace(JOURNEY_DELIMITER, ', '), node[1])) for node in path] for path in paths]
 
@@ -132,7 +132,7 @@ def merge_paths(path1, path2):
     return merged_path
 
 
-def compile_journey(connectivity_statement) -> List[str]:
+def compile_journey(connectivity_statement) -> dict:
     """
    Generates a string of descriptions of journey paths for a given connectivity statement.
 
@@ -153,7 +153,16 @@ def compile_journey(connectivity_statement) -> List[str]:
 
     # Generate all paths and then consolidate them
     all_paths = generate_paths(origins, vias, destinations)
-    journey_paths = consolidate_paths(all_paths)
+    consolidated_paths, journey_paths = consolidate_paths(all_paths)
+
+    entities = []
+    for path in consolidated_paths:
+        entity = {
+            'origins': path[0][0].split(JOURNEY_DELIMITER),
+            'destinations': path[-1][0].split(JOURNEY_DELIMITER),
+            'vias': [node for node, layer in path if 0 < layer < len(vias) + 1]
+        }
+        entities.append(entity)
 
     # Create sentences for each journey path
     journey_descriptions = []
@@ -169,4 +178,7 @@ def compile_journey(connectivity_statement) -> List[str]:
 
         journey_descriptions.append(sentence)
 
-    return journey_descriptions
+    return {
+        'journey': journey_descriptions,
+        'entities': entities
+    }

--- a/backend/composer/services/graph_service.py
+++ b/backend/composer/services/graph_service.py
@@ -15,13 +15,13 @@ def generate_paths(origins, vias, destinations):
             # Directly use pre-fetched 'from_entities' without triggering additional queries
             if origin in destination.from_entities.all() or (not destination.from_entities.exists() and len(vias) == 0):
                 for dest_entity in destination.anatomical_entities.all():
-                    paths.append([(origin.name, 0), (dest_entity.name, destination_layer)])
+                    paths.append([(str(origin.id), origin.name, 0), (str(dest_entity.id), dest_entity.name, destination_layer)])
 
     # Handle connections involving vias
     if vias:
         for origin in origins:
             # Generate paths through vias for each origin
-            paths.extend(create_paths_from_origin(origin, vias, destinations, [(origin.name, 0)], destination_layer))
+            paths.extend(create_paths_from_origin(origin, vias, destinations, [(str(origin.id), origin.name, 0)], destination_layer))
 
     # Remove duplicates from the generated paths
     unique_paths = [list(path) for path in set(tuple(path) for path in paths)]
@@ -33,9 +33,9 @@ def create_paths_from_origin(origin, vias, destinations, current_path, destinati
     # Base case: if there are no more vias to process
     if not vias:
         # Generate direct connections from the current path to destinations
-        return [current_path + [(dest_entity.name, destination_layer)] for dest in destinations
+        return [current_path + [(str(dest_entity.id), dest_entity.name, destination_layer)] for dest in destinations
                 for dest_entity in dest.anatomical_entities.all()
-                if current_path[-1][0] in list(
+                if current_path[-1][1] in list(
                 a.name for a in dest.from_entities.all()) or not dest.from_entities.exists()]
 
     new_paths = []
@@ -45,11 +45,11 @@ def create_paths_from_origin(origin, vias, destinations, current_path, destinati
         # This checks if the last node in the current path is one of the nodes that can lead to the current via.
         # In other words, it checks if there is a valid connection
         # from the last node in the current path to the current via.
-        if (current_path[-1][0] in list(a.name for a in current_via.from_entities.all())
-                or (not current_via.from_entities.exists() and current_path[-1][1] == via_layer - 1)):
+        if (current_path[-1][1] in list(a.name for a in current_via.from_entities.all())
+                or (not current_via.from_entities.exists() and current_path[-1][2] == via_layer - 1)):
             for entity in current_via.anatomical_entities.all():
                 # Build new sub-paths including the current via entity
-                new_sub_path = current_path + [(entity.name, via_layer)]
+                new_sub_path = current_path + [(str(entity.id), entity.name, via_layer)]
                 # Recursively call to build paths from the next vias
                 new_paths.extend(create_paths_from_origin(origin, vias[idx + 1:], destinations,
                                                           new_sub_path, destination_layer))
@@ -59,8 +59,8 @@ def create_paths_from_origin(origin, vias, destinations, current_path, destinati
                     for dest_entity in dest.anatomical_entities.all():
                         if entity.name in list(a.name for a in dest.from_entities.all()):
                             # Add path to destinations directly from the current via
-                            new_paths.append(new_sub_path + [(dest_entity.name, destination_layer)])
-
+                            new_paths.append(new_sub_path + [(str(dest_entity.id), dest_entity.name, destination_layer)])
+    
     return new_paths
 
 
@@ -88,9 +88,9 @@ def consolidate_paths(paths):
 
         paths = consolidated + [paths[i] for i in range(len(paths)) if i not in used_indices]
 
-    return paths, [[((node[0].replace(JOURNEY_DELIMITER, ' or '), node[1]) if (
-            node[1] == 0 or path.index(node) == len(path) - 1) else (
-        node[0].replace(JOURNEY_DELIMITER, ', '), node[1])) for node in path] for path in paths]
+    return paths, [[((node[1].replace(JOURNEY_DELIMITER, ' or '), node[2]) if (
+            node[2] == 0 or path.index(node) == len(path) - 1) else (
+        node[1].replace(JOURNEY_DELIMITER, ', '), node[2])) for node in path] for path in paths]
 
 
 def can_merge(path1, path2):
@@ -99,7 +99,7 @@ def can_merge(path1, path2):
         return False
 
     differences = 0
-    for (p1, layer1), (p2, layer2) in zip(path1, path2):
+    for (p1_id, p1, layer1), (p2_id, p2, layer2) in zip(path1, path2):
         # Split nodes into individual entities
         p1_entities = set(p1.split(JOURNEY_DELIMITER))
         p2_entities = set(p2.split(JOURNEY_DELIMITER))
@@ -123,12 +123,24 @@ def can_merge(path1, path2):
 
 def merge_paths(path1, path2):
     merged_path = []
-    for (p1, layer1), (p2, layer2) in zip(path1, path2):
+    for (p1_id, p1, layer1), (p2_id, p2, layer2) in zip(path1, path2):
         if p1 == p2 and layer1 == layer2:
-            merged_path.append((p1, layer1))
+            merged_path.append((p1_id, p1, layer1))
         else:
-            merged_nodes = set(p1.split(JOURNEY_DELIMITER) + p2.split(JOURNEY_DELIMITER))
-            merged_path.append((JOURNEY_DELIMITER.join(sorted(merged_nodes)), layer1))
+            p1_ids = str(p1_id).split(JOURNEY_DELIMITER)
+            p2_ids = str(p2_id).split(JOURNEY_DELIMITER)
+            p1_nodes = p1.split(JOURNEY_DELIMITER)
+            p2_nodes = p2.split(JOURNEY_DELIMITER)
+            merged_nodes = set(p1_nodes + p2_nodes)
+            merged_nodes_dict = {}
+            for i in range(len(p1_nodes)):
+                merged_nodes_dict[p1_nodes[i]] = p1_ids[i]
+            for i in range(len(p2_nodes)):
+                merged_nodes_dict[p2_nodes[i]] = p2_ids[i]
+            
+            sorted_merged_nodes = sorted(merged_nodes)
+            sorted_merged_nodes_id = [merged_nodes_dict[node] for node in sorted_merged_nodes]  ## also set the node ids in the same order
+            merged_path.append((JOURNEY_DELIMITER.join(sorted_merged_nodes_id), JOURNEY_DELIMITER.join(sorted_merged_nodes), layer1))
     return merged_path
 
 
@@ -152,15 +164,21 @@ def compile_journey(connectivity_statement) -> dict:
     destinations = list(Destination.objects.filter(connectivity_statement=connectivity_statement))
 
     # Generate all paths and then consolidate them
-    all_paths = generate_paths(origins, vias, destinations)
-    consolidated_paths, journey_paths = consolidate_paths(all_paths)
+    all_paths2 = generate_paths(origins, vias, destinations)
+    consolidated_paths, journey_paths = consolidate_paths(all_paths2)
 
     entities = []
     for path in consolidated_paths:
+        origin_splits = path[0][0].split(JOURNEY_DELIMITER)
+        destination_splits = path[-1][0].split(JOURNEY_DELIMITER)
         entity = {
-            'origins': path[0][0].split(JOURNEY_DELIMITER),
-            'destinations': path[-1][0].split(JOURNEY_DELIMITER),
-            'vias': [node for node, layer in path if 0 < layer < len(vias) + 1]
+            'origins': [
+                {'label': path[0][1].split(JOURNEY_DELIMITER)[i], 'id': path[0][0].split(JOURNEY_DELIMITER)[i]} for i in range(len(origin_splits))
+            ],
+            'destinations': [
+                {'label': path[-1][1].split(JOURNEY_DELIMITER)[i], 'id': path[-1][0].split(JOURNEY_DELIMITER)[i]} for i in range(len(destination_splits))
+            ],
+            'vias': [{'label': node, 'id': node_id} for node_id, node, layer in path if 0 < layer < len(vias) + 1]
         }
         entities.append(entity)
 

--- a/backend/tests/test_journey.py
+++ b/backend/tests/test_journey.py
@@ -48,8 +48,8 @@ class JourneyTestCase(TestCase):
 
         # Test execution
         expected_paths = [
-            [('Oa', 0), ('V1a', 1), ('Da', 2)],
-            [('Ob', 0), ('Da', 2)]
+            [('1', 'Oa', 0), ('3', 'V1a', 1), ('4', 'Da', 2)],
+            [('2', 'Ob', 0), ('4', 'Da', 2)]
         ]
 
         all_paths = generate_paths(origins, vias, destinations)
@@ -63,8 +63,13 @@ class JourneyTestCase(TestCase):
             [('Oa', 0), ('V1a', 1), ('Da', 2)],
             [('Ob', 0), ('Da', 2)]
         ]
+        expected_consolidated_path = [
+            [('1', 'Oa', 0), ('3', 'V1a', 1), ('4', 'Da', 2)],
+            [('2', 'Ob', 0), ('4', 'Da', 2)]
+        ]
         journey_paths.sort()
         expected_journey.sort()
+        self.assertTrue(consolidated_path == expected_consolidated_path)
         self.assertTrue(journey_paths == expected_journey)
 
     def test_journey_simple_direct_graph(self):
@@ -98,8 +103,8 @@ class JourneyTestCase(TestCase):
                                                                                    'from_entities'))
 
         expected_paths = [
-            [('Oa', 0), ('Da', 1)],
-            [('Ob', 0), ('Da', 1)]
+            [('1', 'Oa', 0), ('3', 'Da', 1)],
+            [('2', 'Ob', 0), ('3', 'Da', 1)]
         ]
 
         all_paths = generate_paths(origins, None, destinations)
@@ -109,8 +114,12 @@ class JourneyTestCase(TestCase):
         self.assertTrue(all_paths == expected_paths)
 
         consolidated_path, journey_paths = consolidate_paths(all_paths)
+        expected_consolidated_path = [
+            [('1\\2', 'Oa\\Ob', 0), ('3', 'Da', 1)],
+        ]
         expected_journey = [[('Oa or Ob', 0), ('Da', 1)]]
         self.assertTrue(journey_paths == expected_journey)
+        self.assertTrue(consolidated_path == expected_consolidated_path)
 
     def test_journey_simple_graph_no_jumps(self):
         #####################################################################
@@ -151,8 +160,8 @@ class JourneyTestCase(TestCase):
                                                                                    'from_entities'))
 
         expected_paths = [
-            [('Ob', 0), ('V1a', 1), ('Da', 2)],
-            [('Oa', 0), ('V1a', 1), ('Da', 2)]
+            [('2', 'Ob', 0), ('3', 'V1a', 1), ('4', 'Da', 2)],
+            [('1', 'Oa', 0), ('3', 'V1a', 1), ('4', 'Da', 2)]
         ]
 
         all_paths = generate_paths(origins, vias, destinations)
@@ -162,8 +171,12 @@ class JourneyTestCase(TestCase):
         self.assertTrue(all_paths == expected_paths)
 
         expected_journey = [[('Oa or Ob', 0), ('V1a', 1), ('Da', 2)]]
+        expected_consolidated_path = [
+            [('1\\2', 'Oa\\Ob', 0), ('3', 'V1a', 1), ('4', 'Da', 2)],
+        ]
         consolidated_path, journey_paths = consolidate_paths(all_paths)
         self.assertTrue(journey_paths == expected_journey)
+        self.assertTrue(consolidated_path == expected_consolidated_path)
 
     def test_journey_multiple_vias_no_jumps(self):
         #####################################################################
@@ -209,10 +222,10 @@ class JourneyTestCase(TestCase):
         all_paths = generate_paths(origins, vias, destinations)
 
         expected_paths = [
-            [('Oa', 0), ('V1a', 1), ('Da', 2)],
-            [('Oa', 0), ('V1b', 1), ('Da', 2)],
-            [('Ob', 0), ('V1a', 1), ('Da', 2)],
-            [('Ob', 0), ('V1b', 1), ('Da', 2)]
+            [('1', 'Oa', 0), ('3', 'V1a', 1), ('5', 'Da', 2)],
+            [('1', 'Oa', 0), ('4', 'V1b', 1), ('5', 'Da', 2)],
+            [('2', 'Ob', 0), ('3', 'V1a', 1), ('5', 'Da', 2)],
+            [('2', 'Ob', 0), ('4', 'V1b', 1), ('5', 'Da', 2)]
         ]
 
         all_paths.sort()
@@ -222,8 +235,13 @@ class JourneyTestCase(TestCase):
         expected_journey = [
             [('Oa or Ob', 0), ('V1a, V1b', 1), ('Da', 2)]
         ]
+        expected_consolidated_path = [
+            [('1\\2', 'Oa\\Ob', 0), ('3\\4', 'V1a\\V1b', 1), ('5', 'Da', 2)]
+
+        ]
         consolidated_path, journey_paths = consolidate_paths(all_paths)
         self.assertTrue(journey_paths == expected_journey)
+        self.assertTrue(consolidated_path == expected_consolidated_path)
 
     def test_journey_complex_graph(self):
         #####################################################################
@@ -286,13 +304,13 @@ class JourneyTestCase(TestCase):
         all_paths = generate_paths(origins, vias, destinations)
 
         expected_paths = [
-            [('Oa', 0), ('V3a', 3), ('Da', 5)],
-            [('Oa', 0), ('V1a', 1), ('V2a', 2), ('V4a', 4), ('Da', 5)],
-            [('Oa', 0), ('V1a', 1), ('V2a', 2), ('V3a', 3), ('Da', 5)],
-            [('Oa', 0), ('V1a', 1), ('V2b', 2), ('Da', 5)],
-            [('Ob', 0), ('V1a', 1), ('V2a', 2), ('V4a', 4), ('Da', 5)],
-            [('Ob', 0), ('V1a', 1), ('V2a', 2), ('V3a', 3), ('Da', 5)],
-            [('Ob', 0), ('V1a', 1), ('V2b', 2), ('Da', 5)]
+            [('1', 'Oa', 0), ('6', 'V3a', 3), ('8', 'Da', 5)],
+            [('1', 'Oa', 0), ('3', 'V1a', 1), ('4', 'V2a', 2), ('7', 'V4a', 4), ('8', 'Da', 5)],
+            [('1', 'Oa', 0), ('3', 'V1a', 1), ('4', 'V2a', 2), ('6', 'V3a', 3), ('8', 'Da', 5)],
+            [('1', 'Oa', 0), ('3', 'V1a', 1), ('5', 'V2b', 2), ('8', 'Da', 5)],
+            [('2', 'Ob', 0), ('3', 'V1a', 1), ('4', 'V2a', 2), ('7', 'V4a', 4), ('8', 'Da', 5)],
+            [('2', 'Ob', 0), ('3', 'V1a', 1), ('4', 'V2a', 2), ('6', 'V3a', 3), ('8', 'Da', 5)],
+            [('2', 'Ob', 0), ('3', 'V1a', 1), ('5', 'V2b', 2), ('8', 'Da', 5)]
         ]
 
         all_paths.sort()
@@ -303,8 +321,15 @@ class JourneyTestCase(TestCase):
                             [('Oa or Ob', 0), ('V1a', 1), ('V2a', 2), ('V4a', 4), ('Da', 5)],
                             [('Oa or Ob', 0), ('V1a', 1), ('V2b', 2), ('Da', 5)],
                             [('Oa', 0), ('V3a', 3), ('Da', 5)]]
+        expected_consolidated_path = [
+            [('1\\2', 'Oa\\Ob', 0), ('3', 'V1a', 1), ('4', 'V2a', 2), ('6', 'V3a', 3), ('8', 'Da', 5)],
+            [('1\\2', 'Oa\\Ob', 0), ('3', 'V1a', 1), ('4', 'V2a', 2), ('7', 'V4a', 4), ('8', 'Da', 5)],
+            [('1\\2', 'Oa\\Ob', 0), ('3', 'V1a', 1), ('5', 'V2b', 2), ('8', 'Da', 5)],
+            [('1', 'Oa', 0), ('6', 'V3a', 3), ('8', 'Da', 5)]
+        ]
         consolidated_path, journey_paths = consolidate_paths(all_paths)
         self.assertTrue(journey_paths == expected_journey)
+        self.assertTrue(consolidated_path == expected_consolidated_path)
 
     def test_journey_complex_graph_2(self):
         sentence = Sentence.objects.create()
@@ -367,19 +392,19 @@ class JourneyTestCase(TestCase):
 
         all_paths = generate_paths(origins, vias, destinations)
         expected_paths = [
-            [('Oa', 0), ('V1a', 1), ('V2a', 2), ('V3a', 3), ('V4a', 4), ('V5a', 5), ('V6a', 6), ('Da', 7)],
-            [('Ob', 0), ('V1a', 1), ('V2a', 2), ('V3a', 3), ('V4a', 4), ('V5a', 5), ('V6a', 6), ('Da', 7)],
-            [('Oa', 0), ('V1a', 1), ('V2b', 2), ('V4a', 4), ('V5a', 5), ('V6a', 6), ('Da', 7)],
-            [('Ob', 0), ('V1a', 1), ('V2b', 2), ('V4a', 4), ('V5a', 5), ('V6a', 6), ('Da', 7)],
-            [('Oa', 0), ('V1a', 1), ('V3a', 3), ('V4a', 4), ('V5a', 5), ('V6a', 6), ('Da', 7)],
-            [('Ob', 0), ('V1a', 1), ('V3a', 3), ('V4a', 4), ('V5a', 5), ('V6a', 6), ('Da', 7)],
+            [('1', 'Oa', 0), ('3', 'V1a', 1), ('4', 'V2a', 2), ('6', 'V3a', 3), ('7', 'V4a', 4), ('8', 'V5a', 5), ('10', 'V6a', 6), ('11', 'Da', 7)],
+            [('2', 'Ob', 0), ('3', 'V1a', 1), ('4', 'V2a', 2), ('6', 'V3a', 3), ('7', 'V4a', 4), ('8', 'V5a', 5), ('10', 'V6a', 6), ('11', 'Da', 7)],
+            [('1', 'Oa', 0), ('3', 'V1a', 1), ('5', 'V2b', 2), ('7', 'V4a', 4), ('8', 'V5a', 5), ('10', 'V6a', 6), ('11', 'Da', 7)],
+            [('2', 'Ob', 0), ('3', 'V1a', 1), ('5', 'V2b', 2), ('7', 'V4a', 4), ('8', 'V5a', 5), ('10', 'V6a', 6), ('11', 'Da', 7)],
+            [('1', 'Oa', 0), ('3', 'V1a', 1), ('6', 'V3a', 3), ('7', 'V4a', 4), ('8', 'V5a', 5), ('10', 'V6a', 6), ('11', 'Da', 7)],
+            [('2', 'Ob', 0), ('3', 'V1a', 1), ('6', 'V3a', 3), ('7', 'V4a', 4), ('8', 'V5a', 5), ('10', 'V6a', 6), ('11', 'Da', 7)],
 
-            [('Oa', 0), ('V1a', 1), ('V2a', 2), ('V3a', 3), ('V4a', 4), ('V5b', 5), ('Da', 7)],
-            [('Ob', 0), ('V1a', 1), ('V2a', 2), ('V3a', 3), ('V4a', 4), ('V5b', 5), ('Da', 7)],
-            [('Oa', 0), ('V1a', 1), ('V2b', 2), ('V4a', 4), ('V5b', 5), ('Da', 7)],
-            [('Ob', 0), ('V1a', 1), ('V2b', 2), ('V4a', 4), ('V5b', 5), ('Da', 7)],
-            [('Oa', 0), ('V1a', 1), ('V3a', 3), ('V4a', 4), ('V5b', 5), ('Da', 7)],
-            [('Ob', 0), ('V1a', 1), ('V3a', 3), ('V4a', 4), ('V5b', 5), ('Da', 7)],
+            [('1', 'Oa', 0), ('3', 'V1a', 1), ('4', 'V2a', 2), ('6', 'V3a', 3), ('7', 'V4a', 4), ('9', 'V5b', 5), ('11', 'Da', 7)],
+            [('2', 'Ob', 0), ('3', 'V1a', 1), ('4', 'V2a', 2), ('6', 'V3a', 3), ('7', 'V4a', 4), ('9', 'V5b', 5), ('11', 'Da', 7)],
+            [('1', 'Oa', 0), ('3', 'V1a', 1), ('5', 'V2b', 2), ('7', 'V4a', 4), ('9', 'V5b', 5), ('11', 'Da', 7)],
+            [('2', 'Ob', 0), ('3', 'V1a', 1), ('5', 'V2b', 2), ('7', 'V4a', 4), ('9', 'V5b', 5), ('11', 'Da', 7)],
+            [('1', 'Oa', 0), ('3', 'V1a', 1), ('6', 'V3a', 3), ('7', 'V4a', 4), ('9', 'V5b', 5), ('11', 'Da', 7)],
+            [('2', 'Ob', 0), ('3', 'V1a', 1), ('6', 'V3a', 3), ('7', 'V4a', 4), ('9', 'V5b', 5), ('11', 'Da', 7)],
         ]
 
         all_paths.sort()
@@ -394,11 +419,21 @@ class JourneyTestCase(TestCase):
             [('Oa or Ob', 0), ('V1a', 1), ('V2b', 2), ('V4a', 4), ('V5b', 5), ('Da', 7)],
             [('Oa or Ob', 0), ('V1a', 1), ('V3a', 3), ('V4a', 4), ('V5b', 5), ('Da', 7)]
         ]
+        expected_consolidated_path = [
+            [('1\\2', 'Oa\\Ob', 0), ('3', 'V1a', 1), ('4', 'V2a', 2), ('6', 'V3a', 3), ('7', 'V4a', 4), ('8', 'V5a', 5), ('10', 'V6a', 6), ('11', 'Da', 7)],
+            [('1\\2', 'Oa\\Ob', 0), ('3', 'V1a', 1), ('5', 'V2b', 2), ('7', 'V4a', 4), ('8', 'V5a', 5), ('10', 'V6a', 6), ('11', 'Da', 7)],
+            [('1\\2', 'Oa\\Ob', 0), ('3', 'V1a', 1), ('4', 'V2a', 2), ('6', 'V3a', 3), ('7', 'V4a', 4), ('9', 'V5b', 5), ('11', 'Da', 7)],
+            [('1\\2', 'Oa\\Ob', 0), ('3', 'V1a', 1), ('6', 'V3a', 3), ('7', 'V4a', 4), ('8', 'V5a', 5), ('10', 'V6a', 6), ('11', 'Da', 7)],
+            [('1\\2', 'Oa\\Ob', 0), ('3', 'V1a', 1), ('5', 'V2b', 2), ('7', 'V4a', 4), ('9', 'V5b', 5), ('11', 'Da', 7)],
+            [('1\\2', 'Oa\\Ob', 0), ('3', 'V1a', 1), ('6', 'V3a', 3), ('7', 'V4a', 4), ('9', 'V5b', 5), ('11', 'Da', 7)]
+        ]
 
         consolidated_path, journey_paths = consolidate_paths(all_paths)
         journey_paths.sort()
         expected_journey.sort()
+        expected_consolidated_path.sort()
         self.assertTrue(journey_paths == expected_journey)
+        self.assertTrue(consolidated_path == expected_consolidated_path)
 
     def test_journey_cycles(self):
         #####################################################################
@@ -438,9 +473,9 @@ class JourneyTestCase(TestCase):
                                                                                    'from_entities'))
 
         expected_paths = [
-            [('Oa', 0), ('Da', 2)],
-            [('Oa', 0), ('Oa', 1), ('Da', 2)],
-            [('Ob', 0), ('Da', 2)]
+            [('1', 'Oa', 0), ('3', 'Da', 2)],
+            [('1', 'Oa', 0), ('1', 'Oa', 1), ('3', 'Da', 2)],
+            [('2', 'Ob', 0), ('3', 'Da', 2)]
         ]
 
         all_paths = generate_paths(origins, vias, destinations)
@@ -453,11 +488,17 @@ class JourneyTestCase(TestCase):
             [('Oa', 0), ('Oa', 1), ('Da', 2)],
             [('Oa or Ob', 0), ('Da', 2)]
         ]
+        expected_consolidated_path = [
+            [('1', 'Oa', 0), ('1', 'Oa', 1), ('3', 'Da', 2)],
+            [('1\\2', 'Oa\\Ob', 0), ('3', 'Da', 2)]
+        ]
 
         consolidated_path, journey_paths = consolidate_paths(all_paths)
         expected_journey.sort()
+        expected_consolidated_path.sort()
         journey_paths.sort()
         self.assertTrue(journey_paths == expected_journey)
+        self.assertTrue(consolidated_path == expected_consolidated_path)
 
     def test_journey_nonconsecutive_vias(self):
         # Test setup
@@ -496,7 +537,7 @@ class JourneyTestCase(TestCase):
                                                                                    'from_entities'))
 
         expected_paths = [
-            [('Oa', 0), ('V1a', 3), ('V2a', 6), ('Da', 7)],
+            [('1', 'Oa', 0), ('2', 'V1a', 3), ('3', 'V2a', 6), ('4', 'Da', 7)],
         ]
 
         all_paths = generate_paths(origins, vias, destinations)
@@ -509,10 +550,15 @@ class JourneyTestCase(TestCase):
         expected_journey = [
             [('Oa', 0), ('V1a', 3), ('V2a', 6), ('Da', 7)],
         ]
+        expected_consolidated_path = [
+            [('1', 'Oa', 0), ('2', 'V1a', 3), ('3', 'V2a', 6), ('4', 'Da', 7)],
+        ]
         journey_paths.sort()
         expected_journey.sort()
+        expected_consolidated_path.sort()
         self.assertTrue(journey_paths == expected_journey,
                         f"Expected journey {expected_journey}, but found {journey_paths}")
+        self.assertTrue(consolidated_path == expected_consolidated_path)
 
     def test_journey_implicit_from_entities(self):
         # Test setup
@@ -548,7 +594,7 @@ class JourneyTestCase(TestCase):
                                                                                    'from_entities'))
 
         expected_paths = [
-            [('Myenteric', 0), ('Longitudinal', 1), ('Serosa', 2), ('lumbar', 3), ('inferior', 4)],
+            [('1', 'Myenteric', 0), ('2', 'Longitudinal', 1), ('3', 'Serosa', 2), ('4', 'lumbar', 3), ('5', 'inferior', 4)],
         ]
 
         all_paths = generate_paths(origins, vias, destinations)
@@ -561,7 +607,12 @@ class JourneyTestCase(TestCase):
         expected_journey = [
             [('Myenteric', 0), ('Longitudinal', 1), ('Serosa', 2), ('lumbar', 3), ('inferior', 4)],
         ]
+        expected_consolidated_path = [
+            [('1', 'Myenteric', 0), ('2', 'Longitudinal', 1), ('3', 'Serosa', 2), ('4', 'lumbar', 3), ('5', 'inferior', 4)],
+        ]
         journey_paths.sort()
         expected_journey.sort()
+        expected_consolidated_path.sort()
         self.assertTrue(journey_paths == expected_journey,
                         f"Expected journey {expected_journey}, but found {journey_paths}")
+        self.assertTrue(consolidated_path == expected_consolidated_path)

--- a/backend/tests/test_journey.py
+++ b/backend/tests/test_journey.py
@@ -58,7 +58,7 @@ class JourneyTestCase(TestCase):
         expected_paths.sort()
         self.assertTrue(all_paths == expected_paths)
 
-        journey_paths = consolidate_paths(all_paths)
+        consolidated_path, journey_paths = consolidate_paths(all_paths)
         expected_journey = [
             [('Oa', 0), ('V1a', 1), ('Da', 2)],
             [('Ob', 0), ('Da', 2)]
@@ -108,7 +108,7 @@ class JourneyTestCase(TestCase):
         expected_paths.sort()
         self.assertTrue(all_paths == expected_paths)
 
-        journey_paths = consolidate_paths(all_paths)
+        consolidated_path, journey_paths = consolidate_paths(all_paths)
         expected_journey = [[('Oa or Ob', 0), ('Da', 1)]]
         self.assertTrue(journey_paths == expected_journey)
 
@@ -162,7 +162,7 @@ class JourneyTestCase(TestCase):
         self.assertTrue(all_paths == expected_paths)
 
         expected_journey = [[('Oa or Ob', 0), ('V1a', 1), ('Da', 2)]]
-        journey_paths = consolidate_paths(all_paths)
+        consolidated_path, journey_paths = consolidate_paths(all_paths)
         self.assertTrue(journey_paths == expected_journey)
 
     def test_journey_multiple_vias_no_jumps(self):
@@ -222,7 +222,7 @@ class JourneyTestCase(TestCase):
         expected_journey = [
             [('Oa or Ob', 0), ('V1a, V1b', 1), ('Da', 2)]
         ]
-        journey_paths = consolidate_paths(all_paths)
+        consolidated_path, journey_paths = consolidate_paths(all_paths)
         self.assertTrue(journey_paths == expected_journey)
 
     def test_journey_complex_graph(self):
@@ -303,7 +303,7 @@ class JourneyTestCase(TestCase):
                             [('Oa or Ob', 0), ('V1a', 1), ('V2a', 2), ('V4a', 4), ('Da', 5)],
                             [('Oa or Ob', 0), ('V1a', 1), ('V2b', 2), ('Da', 5)],
                             [('Oa', 0), ('V3a', 3), ('Da', 5)]]
-        journey_paths = consolidate_paths(all_paths)
+        consolidated_path, journey_paths = consolidate_paths(all_paths)
         self.assertTrue(journey_paths == expected_journey)
 
     def test_journey_complex_graph_2(self):
@@ -395,7 +395,7 @@ class JourneyTestCase(TestCase):
             [('Oa or Ob', 0), ('V1a', 1), ('V3a', 3), ('V4a', 4), ('V5b', 5), ('Da', 7)]
         ]
 
-        journey_paths = consolidate_paths(all_paths)
+        consolidated_path, journey_paths = consolidate_paths(all_paths)
         journey_paths.sort()
         expected_journey.sort()
         self.assertTrue(journey_paths == expected_journey)
@@ -454,7 +454,7 @@ class JourneyTestCase(TestCase):
             [('Oa or Ob', 0), ('Da', 2)]
         ]
 
-        journey_paths = consolidate_paths(all_paths)
+        consolidated_path, journey_paths = consolidate_paths(all_paths)
         expected_journey.sort()
         journey_paths.sort()
         self.assertTrue(journey_paths == expected_journey)
@@ -505,7 +505,7 @@ class JourneyTestCase(TestCase):
         expected_paths.sort()
         self.assertTrue(all_paths == expected_paths, f"Expected paths {expected_paths}, but found {all_paths}")
 
-        journey_paths = consolidate_paths(all_paths)
+        consolidated_path, journey_paths = consolidate_paths(all_paths)
         expected_journey = [
             [('Oa', 0), ('V1a', 3), ('V2a', 6), ('Da', 7)],
         ]
@@ -557,7 +557,7 @@ class JourneyTestCase(TestCase):
         expected_paths.sort()
         self.assertTrue(all_paths == expected_paths, f"Expected paths {expected_paths}, but found {all_paths}")
 
-        journey_paths = consolidate_paths(all_paths)
+        consolidated_path, journey_paths = consolidate_paths(all_paths)
         expected_journey = [
             [('Myenteric', 0), ('Longitudinal', 1), ('Serosa', 2), ('lumbar', 3), ('inferior', 4)],
         ]

--- a/frontend/src/apiclient/backend/api.ts
+++ b/frontend/src/apiclient/backend/api.ts
@@ -68,16 +68,16 @@ export interface AnatomicalEntityIntersection {
     'id': number;
     /**
      * 
-     * @type {Layer}
+     * @type {AnatomicalEntityMeta}
      * @memberof AnatomicalEntityIntersection
      */
-    'layer': Layer;
+    'layer': AnatomicalEntityMeta;
     /**
      * 
-     * @type {Region}
+     * @type {AnatomicalEntityMeta}
      * @memberof AnatomicalEntityIntersection
      */
-    'region': Region;
+    'region': AnatomicalEntityMeta;
 }
 /**
  * 
@@ -324,6 +324,12 @@ export interface ConnectivityStatement {
      * @memberof ConnectivityStatement
      */
     'journey': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof ConnectivityStatement
+     */
+    'entities_journey': string;
     /**
      * 
      * @type {ConnectivityStatementLaterality}
@@ -784,6 +790,12 @@ export interface KnowledgeStatement {
     'journey': string;
     /**
      * 
+     * @type {string}
+     * @memberof KnowledgeStatement
+     */
+    'entities_journey': string;
+    /**
+     * 
      * @type {ConnectivityStatementLaterality}
      * @memberof KnowledgeStatement
      */
@@ -827,31 +839,6 @@ export const LateralityEnum = {
 export type LateralityEnum = typeof LateralityEnum[keyof typeof LateralityEnum];
 
 
-/**
- * 
- * @export
- * @interface Layer
- */
-export interface Layer {
-    /**
-     * 
-     * @type {number}
-     * @memberof Layer
-     */
-    'id': number;
-    /**
-     * 
-     * @type {string}
-     * @memberof Layer
-     */
-    'name': string;
-    /**
-     * 
-     * @type {string}
-     * @memberof Layer
-     */
-    'ontology_uri': string;
-}
 /**
  * 
  * @export
@@ -1848,12 +1835,6 @@ export interface ProjectionPhenotype {
      * @memberof ProjectionPhenotype
      */
     'name': string;
-    /**
-     * 
-     * @type {string}
-     * @memberof ProjectionPhenotype
-     */
-    'ontology_uri': string;
 }
 /**
  * Provenance
@@ -1879,37 +1860,6 @@ export interface Provenance {
      * @memberof Provenance
      */
     'connectivity_statement_id': number;
-}
-/**
- * 
- * @export
- * @interface Region
- */
-export interface Region {
-    /**
-     * 
-     * @type {number}
-     * @memberof Region
-     */
-    'id': number;
-    /**
-     * 
-     * @type {string}
-     * @memberof Region
-     */
-    'name': string;
-    /**
-     * 
-     * @type {string}
-     * @memberof Region
-     */
-    'ontology_uri': string;
-    /**
-     * 
-     * @type {Array<Layer>}
-     * @memberof Region
-     */
-    'layers': Array<Layer>;
 }
 /**
  * Sentence

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1914,11 +1914,11 @@ components:
           readOnly: true
         layer:
           allOf:
-          - $ref: '#/components/schemas/Layer'
+          - $ref: '#/components/schemas/AnatomicalEntityMeta'
           readOnly: true
         region:
           allOf:
-          - $ref: '#/components/schemas/Region'
+          - $ref: '#/components/schemas/AnatomicalEntityMeta'
           readOnly: true
       required:
       - id
@@ -2072,6 +2072,9 @@ components:
         journey:
           type: string
           readOnly: true
+        entities_journey:
+          type: string
+          readOnly: true
         laterality:
           nullable: true
           oneOf:
@@ -2128,6 +2131,7 @@ components:
           readOnly: true
       required:
       - available_transitions
+      - entities_journey
       - errors
       - has_notes
       - id
@@ -2381,6 +2385,9 @@ components:
         journey:
           type: string
           readOnly: true
+        entities_journey:
+          type: string
+          readOnly: true
         laterality:
           nullable: true
           oneOf:
@@ -2407,6 +2414,7 @@ components:
           type: string
           readOnly: true
       required:
+      - entities_journey
       - id
       - journey
       - phenotype
@@ -2417,23 +2425,6 @@ components:
       - RIGHT
       - LEFT
       type: string
-    Layer:
-      type: object
-      properties:
-        id:
-          type: integer
-          readOnly: true
-        name:
-          type: string
-          maxLength: 200
-        ontology_uri:
-          type: string
-          format: uri
-          maxLength: 200
-      required:
-      - id
-      - name
-      - ontology_uri
     Login:
       type: object
       properties:
@@ -3021,14 +3012,9 @@ components:
         name:
           type: string
           maxLength: 200
-        ontology_uri:
-          type: string
-          format: uri
-          maxLength: 200
       required:
       - id
       - name
-      - ontology_uri
     Provenance:
       type: object
       description: Provenance
@@ -3044,29 +3030,6 @@ components:
       - connectivity_statement_id
       - id
       - uri
-    Region:
-      type: object
-      properties:
-        id:
-          type: integer
-          readOnly: true
-        name:
-          type: string
-          maxLength: 200
-        ontology_uri:
-          type: string
-          format: uri
-          maxLength: 200
-        layers:
-          type: array
-          items:
-            $ref: '#/components/schemas/Layer'
-          readOnly: true
-      required:
-      - id
-      - layers
-      - name
-      - ontology_uri
     Sentence:
       type: object
       description: Sentence


### PR DESCRIPTION
- Added a new serializer field - `entities_journey`. This returns all the vias, destinations, and origins of that respective KS. 
- 
```
it is of the form:

entitiesJourney: EntitiesJourneyType[]

where EntitiesJourneyType  is;

export type EntitiesJourneyType = {
  origins: string[];
  vias: string[];
  destinations: string[];
};

```


- Each string in origin, vias, destination - is the name of that origin/via/destination.
- We get this information from the - [consolidated_paths](https://github.com/MetaCell/sckan-composer/blob/82c22ad198728d48113d554bfed688dc0b350f0f/backend/composer/services/graph_service.py#L91).