### PR TITLE
update NLP sentence form check

### DIFF
--- a/frontend/src/Pages/SentenceDetails.tsx
+++ b/frontend/src/Pages/SentenceDetails.tsx
@@ -10,9 +10,10 @@ import TagForm from "../components/Forms/TagForm";
 import {
   Sentence,
   SentenceConnectivityStatement,
-  SentenceAvailableTransitionsEnum, ComposerSentenceListStateEnum,
+  SentenceAvailableTransitionsEnum,
+  ComposerSentenceListStateEnum,
+  SentenceAvailableTransitionsEnum as SentenceStates,
 } from "../apiclient/backend/api";
-import { userProfile } from "../services/UserService";
 import CheckDuplicates from "../components/CheckForDuplicates/CheckDuplicatesDialog";
 import { SentenceStateChip } from "../components/Widgets/StateChip";
 import { SentenceLabels, formatDate, formatTime } from "../helpers/helpers";
@@ -203,7 +204,7 @@ const SentencesDetails = () => {
     );
   }
 
-  const isDisabled = sentence.owner?.id !== userProfile.getUser().id;
+  const isDisabled = sentence?.state === SentenceStates.ComposeNow;
 
   return (
     <Grid p={6} container>
@@ -278,7 +279,7 @@ const SentencesDetails = () => {
                     handleClick={handleClick}
                     selectedOption={
                       SentenceLabels[
-                        sentence?.available_transitions[selectedIndex]
+                        sentence?.available_transitions?.[selectedIndex]
                       ]
                     }
                     options={sentence?.available_transitions}

--- a/frontend/src/components/Forms/SentenceForm.tsx
+++ b/frontend/src/components/Forms/SentenceForm.tsx
@@ -71,7 +71,7 @@ const SentenceForm = (props: any) => {
     ...schema,
     "title": ""
   }
-
+  console.log(data)
   return (
     <Paper sx={sectionStyle}>
       <Box mb={3}>

--- a/frontend/src/helpers/ownershipAlert.ts
+++ b/frontend/src/helpers/ownershipAlert.ts
@@ -66,7 +66,7 @@ export const checkSentenceOwnership = (
             sentenceService.assignOwner(fetchedData.id, {})
               .then(() => {
                 return onSave(fetchedData, userId)
-                  .then(() => resolve(ChangeRequestStatus.SAVED))
+                  .then(() => resolve(fetchedData))
                   .catch((error) => reject(error));
               })
               .catch((error) => {
@@ -75,11 +75,11 @@ export const checkSentenceOwnership = (
               });
           } else {
             onCancel(fetchedData, userId);
-            resolve(ChangeRequestStatus.CANCELLED);
+            resolve(fetchedData);
           }
         } else {
           onSave(fetchedData, userId)
-            .then(() => resolve(ChangeRequestStatus.SAVED))
+            .then(() => resolve(fetchedData))
             .catch((error) => reject(error));
         }
       })


### PR DESCRIPTION
Updated the NLP logic to handle ownership, addressing feedback from [PR #342 discussion](https://github.com/MetaCell/sckan-composer/pull/342#discussion_r1824422388). Additionally, modified the UI components so that the disabled state now reflects the sentence status rather than ownership.