### PR TITLE
SCKAN-341 fix: Update isOwner permission to check for related entity …

### DIFF
--- a/backend/composer/api/permissions.py
+++ b/backend/composer/api/permissions.py
@@ -25,8 +25,8 @@ class IsOwnerOrAssignOwnerOrCreateOrReadOnly(permissions.BasePermission):
         if request.method in permissions.SAFE_METHODS:
             return True
 
-        # Checks if creator is the owner of the related entity (if related entity exists)
-        if request.method == 'POST':
+        # If creating a new instance, ensure related entity ownership
+        if request.method == 'POST' and view.action == 'create':
             return check_related_entity_ownership(request)
 
         # For unsafe methods (PATCH, PUT, DELETE), allow only authenticated users
@@ -58,25 +58,6 @@ class IsOwnerOfConnectivityStatementOrReadOnly(permissions.BasePermission):
         # Write permissions are only allowed to the owner of the related ConnectivityStatement
         return obj.connectivity_statement.owner == request.user
     
-
-class IsSentenceOrStatementOwnerOrSystemUserOrReadOnly(permissions.BasePermission):
-    """
-    Custom permission to allow:
-    - System user to bypass all checks.
-    - Only the owner of a sentence or connectivity statement can create a note.
-    """
-
-    def has_permission(self, request, view):
-        # Allow system user to bypass all checks
-        if request.user.username == 'system' and request.user.is_staff:
-            return True
-
-        # Allow read-only access (GET, HEAD, OPTIONS)
-        if request.method in permissions.SAFE_METHODS:
-            return True
-
-        # For POST (create), PUT, PATCH (update), or DELETE, check ownership
-        return check_related_entity_ownership(request)
 
 
 def check_related_entity_ownership(request):

--- a/backend/composer/api/views.py
+++ b/backend/composer/api/views.py
@@ -45,7 +45,6 @@ from .serializers import (
     BaseConnectivityStatementSerializer,
 )
 from .permissions import (
-    IsSentenceOrStatementOwnerOrSystemUserOrReadOnly,
     IsStaffUserIfExportedStateInConnectivityStatement,
     IsOwnerOrAssignOwnerOrCreateOrReadOnly,
     IsOwnerOfConnectivityStatementOrReadOnly,

--- a/backend/composer/api/views.py
+++ b/backend/composer/api/views.py
@@ -320,7 +320,9 @@ class NoteViewSet(viewsets.ModelViewSet):
 
     queryset = Note.objects.all()
     serializer_class = NoteSerializer
-    permission_classes = []
+    permission_classes = [
+                permissions.IsAuthenticatedOrReadOnly,
+    ]
     filterset_class = NoteFilter
 
 


### PR DESCRIPTION
closes https://metacell.atlassian.net/browse/SCKAN-341

- The IsOwnerOrAssignOwnerOrCreateOrReadOnly was checking for the sentence ownership in both statement creation and statement state transitions. The check only makes sense to occur for statement creation. The current PR applies that change.

- It also removes a permission no longer used (was previously used to limit note creation to entity owners which is no longer desired)