### PR TITLE
SCKAN-342 fix: Refresh statement after via/destination creation

### DIFF
--- a/frontend/src/components/Forms/StatementForm.tsx
+++ b/frontend/src/components/Forms/StatementForm.tsx
@@ -219,6 +219,7 @@ const StatementForm = (props: any) => {
             anatomical_entities: [],
             from_entities: [],
           });
+          refreshStatement();
         }}
         onElementReorder={async (
           sourceIndex: number,
@@ -422,6 +423,7 @@ const StatementForm = (props: any) => {
             anatomical_entities: [],
             from_entities: [],
           });
+          refreshStatement();
         }}
         hideDeleteBtn={statement?.destinations?.length <= 1 || isDisabled}
         showReOrderingIcon={false}


### PR DESCRIPTION
closes https://metacell.atlassian.net/browse/SCKAN-342

- Refreshes statement after creating vias/destinations

https://github.com/user-attachments/assets/735fb9d0-5624-44a5-9e52-0cf276e0c88f

