### PR TITLE
Feature/sckan-273 

### DIFF
--- a/backend/composer/models.py
+++ b/backend/composer/models.py
@@ -634,7 +634,10 @@ class ConnectivityStatement(models.Model):
 
     @transition(
         field=state,
-        source=CSState.NPO_APPROVED,
+        source=[
+            CSState.NPO_APPROVED,
+            CSState.INVALID
+        ],
         target=CSState.EXPORTED,
         conditions=[ConnectivityStatementStateService.is_valid],
         permission=ConnectivityStatementStateService.has_permission_to_transition_to_exported,

--- a/backend/composer/services/cs_ingestion/helpers/notes_helper.py
+++ b/backend/composer/services/cs_ingestion/helpers/notes_helper.py
@@ -26,3 +26,9 @@ def create_invalid_note(connectivity_statement: ConnectivityStatement, note: str
         type=NoteType.ALERT,
         note=f"Invalidated due to the following reason(s): {note}"
     )
+
+
+def do_transition_to_exported(connectivity_statement: ConnectivityStatement):
+    system_user = User.objects.get(username="system")
+    connectivity_statement.exported(by=system_user)
+    connectivity_statement.save()

--- a/backend/composer/services/cs_ingestion/helpers/statement_helper.py
+++ b/backend/composer/services/cs_ingestion/helpers/statement_helper.py
@@ -12,7 +12,7 @@ from composer.services.cs_ingestion.helpers.common_helpers import LABEL, VALIDAT
 from composer.services.cs_ingestion.helpers.getters import get_sex, get_circuit_type, get_functional_circuit_role, \
     get_phenotype, get_projection_phenotype
 from composer.services.cs_ingestion.helpers.notes_helper import do_transition_to_invalid_with_note, create_invalid_note, \
-    add_ingestion_system_note
+    add_ingestion_system_note, do_transition_to_exported
 from composer.services.cs_ingestion.models import ValidationErrors
 
 
@@ -50,6 +50,9 @@ def create_or_update_connectivity_statement(statement: Dict, sentence: Sentence,
             do_transition_to_invalid_with_note(connectivity_statement, error_message)
         else:
             create_invalid_note(connectivity_statement, error_message)
+    else:
+        if connectivity_statement.state != CSState.EXPORTED:
+            do_transition_to_exported(connectivity_statement)
 
     update_many_to_many_fields(connectivity_statement, statement, update_anatomical_entities)
     statement[STATE] = connectivity_statement.state

--- a/backend/composer/services/cs_ingestion/helpers/statement_helper.py
+++ b/backend/composer/services/cs_ingestion/helpers/statement_helper.py
@@ -35,11 +35,11 @@ def create_or_update_connectivity_statement(statement: Dict, sentence: Sentence,
         reference_uri=reference_uri,
         defaults=defaults
     )
-    if not created:
+    if not created:        
         if has_changes(connectivity_statement, statement, defaults):
-            ConnectivityStatement.objects.filter(reference_uri=reference_uri).update(**defaults)
-            fields_to_refresh = [field for field in defaults.keys() if field != 'state']
-            connectivity_statement.refresh_from_db(fields=fields_to_refresh)
+            defaults_without_state = {field: value for field, value in defaults.items() if field != 'state'}
+            ConnectivityStatement.objects.filter(reference_uri=reference_uri).update(**defaults_without_state)
+            connectivity_statement = ConnectivityStatement.objects.filter(reference_uri=reference_uri).first()
             add_ingestion_system_note(connectivity_statement)
 
     validation_errors = statement.get(VALIDATION_ERRORS, ValidationErrors())

--- a/backend/composer/services/cs_ingestion/helpers/statement_helper.py
+++ b/backend/composer/services/cs_ingestion/helpers/statement_helper.py
@@ -39,7 +39,7 @@ def create_or_update_connectivity_statement(statement: Dict, sentence: Sentence,
         if has_changes(connectivity_statement, statement, defaults):
             defaults_without_state = {field: value for field, value in defaults.items() if field != 'state'}
             ConnectivityStatement.objects.filter(reference_uri=reference_uri).update(**defaults_without_state)
-            connectivity_statement = ConnectivityStatement.objects.filter(reference_uri=reference_uri).first()
+            connectivity_statement = ConnectivityStatement.objects.get(reference_uri=reference_uri)
             add_ingestion_system_note(connectivity_statement)
 
     validation_errors = statement.get(VALIDATION_ERRORS, ValidationErrors())


### PR DESCRIPTION
Jira ticket - [SCKAN-273](https://metacell.atlassian.net/browse/SCKAN-273)

About the issue - of statements getting converted from exported to invalid and vice versa. 


Previously:
`ConnectivityStatement.objects.filter(reference_uri=reference_uri).update(**defaults)`

IMO - we should not update the [default state](https://github.com/MetaCell/sckan-composer/blob/79c5ff869fcf3e39f53e8345e50a1acb739a933f/backend/composer/services/cs_ingestion/helpers/statement_helper.py#L22) here (since the default state is [EXPORTED](https://github.com/MetaCell/sckan-composer/blob/79c5ff869fcf3e39f53e8345e50a1acb739a933f/backend/composer/services/cs_ingestion/helpers/statement_helper.py#L22)). So the problem we were facing - happened because if the statement had any changes, then - it was getting [converted to EXPORTED](https://github.com/MetaCell/sckan-composer/blob/79c5ff869fcf3e39f53e8345e50a1acb739a933f/backend/composer/services/cs_ingestion/helpers/statement_helper.py#L40).


<hr />


This alone should fix the issue. Since now - it is not getting converted to EXPORTED, and hence would not be needing the conversion back to INVALID. However following is a `good to have`.

i.e. 
`connectivity_statement = ConnectivityStatement.objects.filter(reference_uri=reference_uri).first()`

instead of 

```
fields_to_refresh = [field for field in defaults.keys() if field != 'state']
connectivity_statement.refresh_from_db(fields=fields_to_refresh)
```

since it doesn't get the latest for the state field. Which later caused errors (before the above fix) [here](https://github.com/MetaCell/sckan-composer/blob/79c5ff869fcf3e39f53e8345e50a1acb739a933f/backend/composer/services/cs_ingestion/helpers/statement_helper.py#L50). 

Example of bad update before:
Once the statement was converted to EXPORTED state due to defaults, [line](https://github.com/MetaCell/sckan-composer/blob/79c5ff869fcf3e39f53e8345e50a1acb739a933f/backend/composer/services/cs_ingestion/helpers/statement_helper.py#L49) still thinks it is in invalid state (and hence doesn't move it to INVALID - but will convert this very statement to INVALID the next time we run the script). However, we did [update](https://github.com/MetaCell/sckan-composer/blob/79c5ff869fcf3e39f53e8345e50a1acb739a933f/backend/composer/services/cs_ingestion/helpers/statement_helper.py#L40) and [fetched the latest](https://github.com/MetaCell/sckan-composer/blob/79c5ff869fcf3e39f53e8345e50a1acb739a933f/backend/composer/services/cs_ingestion/helpers/statement_helper.py#L42) the before. 






[SCKAN-273]: https://metacell.atlassian.net/browse/SCKAN-273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ