### PR TITLE
SCKAN-323 fix: Update frontend to send new owner_id on retry

### DIFF
--- a/backend/composer/api/serializers.py
+++ b/backend/composer/api/serializers.py
@@ -706,7 +706,7 @@ class ConnectivityStatementUpdateSerializer(ConnectivityStatementSerializer):
             "errors",
             "graph_rendering_state",
         )
-        read_only_fields = ("owner", "owner_id")
+        read_only_fields = ("state","owner", "owner_id")
 
     def update(self, instance, validated_data):
         validated_data.pop("owner", None)
@@ -730,7 +730,6 @@ class ConnectivityStatementUpdateSerializer(ConnectivityStatementSerializer):
         if origins is not None:
             instance.origins.set(origins)
 
-        # Proceed with the standard update
         return super().update(instance, validated_data)
 
     def to_representation(self, instance):

--- a/backend/composer/api/serializers.py
+++ b/backend/composer/api/serializers.py
@@ -2,6 +2,7 @@ from typing import List
 
 from django.contrib.auth.models import User
 from django.db.models import Q
+from django.forms import ValidationError
 from django_fsm import FSMField
 from drf_writable_nested.mixins import UniqueFieldsMixin
 from drf_writable_nested.serializers import WritableNestedModelSerializer
@@ -703,8 +704,41 @@ class ConnectivityStatementUpdateSerializer(ConnectivityStatementSerializer):
             "has_notes",
             "statement_preview",
             "errors",
-            "graph_rendering_state"
+            "graph_rendering_state",
         )
+        read_only_fields = ("owner", "owner_id")
+
+    def update(self, instance, validated_data):
+        validated_data.pop("owner", None)
+        validated_data.pop("owner_id", None)
+
+        graph_rendering_state_data = validated_data.pop("graph_rendering_state", None)
+        if graph_rendering_state_data is not None:
+            graph_state, _ = GraphRenderingState.objects.get_or_create(
+                connectivity_statement=instance, defaults={"serialized_graph": {}}
+            )
+
+            # Update the serialized_graph with incoming data
+            graph_state.serialized_graph = graph_rendering_state_data.get(
+                "serialized_graph", graph_state.serialized_graph
+            )
+            graph_state.saved_by = self.context["request"].user
+            graph_state.save()
+
+        # Handle origins
+        origins = validated_data.pop("origins", None)
+        if origins is not None:
+            instance.origins.set(origins)
+
+        # Proceed with the standard update
+        return super().update(instance, validated_data)
+
+    def to_representation(self, instance):
+        """
+        After updating, use the main serializer to represent the instance,
+        ensuring that 'origins' are serialized as full objects.
+        """
+        return ConnectivityStatementSerializer(instance, context=self.context).data
 
 
 class KnowledgeStatementSerializer(ConnectivityStatementSerializer):

--- a/frontend/src/apiclient/backend/.openapi-generator/FILES
+++ b/frontend/src/apiclient/backend/.openapi-generator/FILES
@@ -1,5 +1,6 @@
 .gitignore
 .npmignore
+.openapi-generator-ignore
 api.ts
 base.ts
 common.ts

--- a/frontend/src/services/StatementService.ts
+++ b/frontend/src/services/StatementService.ts
@@ -49,10 +49,9 @@ class ConnectivityStatementService extends AbstractService {
       return await checkOwnership(
         id,
         // Retry the update after ownership is reassigned, including new owner ID
-        async () => {
-          const updatedStatement = {
-            ...connectivityStatement,
-          };
+        async (fetchedData, userId) => {
+          // Update the statement with the new ownership if reassigned
+          const updatedStatement = { ...connectivityStatement, owner_id: userId };
           await composerApi.composerConnectivityStatementUpdate(id, updatedStatement).then((response: any) => response.data);
           return ChangeRequestStatus.SAVED;
         },


### PR DESCRIPTION
closes https://metacell.atlassian.net/browse/SCKAN-323

Error explained:
- The frontend was making an update request that included a change of owner.
- The backend applied the change and then ran into a permission error on a post processing step

Solution:
- This PR changes the frontend request to include the correct/desired owner for the statement
- It also refactors the backend to move the update logic from the view to the serializer.
- Makes the owner and owner_id read_only on the update and provides a more descriptive error message when those are included in the incoming request


https://github.com/user-attachments/assets/7c022c2d-2d14-46f5-9190-9ac39a17dc73


