### PR TITLE
refactor: Rename enum types

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/4.1/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.1/ref/settings/
 """
+
 import os
 from pathlib import Path
 
@@ -68,7 +69,6 @@ INSTALLED_APPS = [
     "nested_admin",
     "django.contrib.admin",
     "social_django",
-
     #
     "corsheaders",
 ]
@@ -353,7 +353,10 @@ SPECTACULAR_SETTINGS = {
     "SWAGGER_UI_DIST": "SIDECAR",  # shorthand to use the sidecar instead
     "SWAGGER_UI_FAVICON_HREF": "SIDECAR",
     "REDOC_DIST": "SIDECAR",
-    # OTHER SETTINGS
+    "ENUM_NAME_OVERRIDES": {
+        "ViaTypeEnum": "composer.enums.ViaType",
+        "DestinationTypeEmum": "composer.enums.DestinationType",
+    },
 }
 
 SOCIAL_AUTH_ORCID_KEY = "APP-GRRGRZ5EZQLQ6WZT"

--- a/frontend/src/apiclient/backend/api.ts
+++ b/frontend/src/apiclient/backend/api.ts
@@ -689,10 +689,10 @@ export interface Destination {
     'connectivity_statement': number;
     /**
      * 
-     * @type {TypeC11Enum}
+     * @type {DestinationTypeEmum}
      * @memberof Destination
      */
-    'type'?: TypeC11Enum;
+    'type'?: DestinationTypeEmum;
     /**
      * 
      * @type {Array<number>}
@@ -728,10 +728,10 @@ export interface DestinationSerializerDetails {
     'connectivity_statement_id': number;
     /**
      * 
-     * @type {TypeC11Enum}
+     * @type {DestinationTypeEmum}
      * @memberof DestinationSerializerDetails
      */
-    'type'?: TypeC11Enum;
+    'type'?: DestinationTypeEmum;
     /**
      * 
      * @type {Array<AnatomicalEntity>}
@@ -751,6 +751,21 @@ export interface DestinationSerializerDetails {
      */
     'are_connections_explicit': string;
 }
+
+
+/**
+ * 
+ * @export
+ * @enum {string}
+ */
+
+export const DestinationTypeEmum = {
+    AxonT: 'AXON-T',
+    AfferentT: 'AFFERENT-T',
+    Unknown: 'UNKNOWN'
+} as const;
+
+export type DestinationTypeEmum = typeof DestinationTypeEmum[keyof typeof DestinationTypeEmum];
 
 
 /**
@@ -1870,10 +1885,10 @@ export interface PatchedDestination {
     'connectivity_statement'?: number;
     /**
      * 
-     * @type {TypeC11Enum}
+     * @type {DestinationTypeEmum}
      * @memberof PatchedDestination
      */
-    'type'?: TypeC11Enum;
+    'type'?: DestinationTypeEmum;
     /**
      * 
      * @type {Array<number>}
@@ -2122,10 +2137,10 @@ export interface PatchedVia {
     'connectivity_statement'?: number;
     /**
      * 
-     * @type {TypeB60Enum}
+     * @type {ViaTypeEnum}
      * @memberof PatchedVia
      */
-    'type'?: TypeB60Enum;
+    'type'?: ViaTypeEnum;
     /**
      * 
      * @type {Array<number>}
@@ -2632,35 +2647,6 @@ export interface Tag {
     'tag': string;
 }
 /**
- * 
- * @export
- * @enum {string}
- */
-
-export const TypeB60Enum = {
-    Axon: 'AXON',
-    Dendrite: 'DENDRITE'
-} as const;
-
-export type TypeB60Enum = typeof TypeB60Enum[keyof typeof TypeB60Enum];
-
-
-/**
- * 
- * @export
- * @enum {string}
- */
-
-export const TypeC11Enum = {
-    AxonT: 'AXON-T',
-    AfferentT: 'AFFERENT-T',
-    Unknown: 'UNKNOWN'
-} as const;
-
-export type TypeC11Enum = typeof TypeC11Enum[keyof typeof TypeC11Enum];
-
-
-/**
  * User
  * @export
  * @interface User
@@ -2729,10 +2715,10 @@ export interface Via {
     'connectivity_statement'?: number;
     /**
      * 
-     * @type {TypeB60Enum}
+     * @type {ViaTypeEnum}
      * @memberof Via
      */
-    'type'?: TypeB60Enum;
+    'type'?: ViaTypeEnum;
     /**
      * 
      * @type {Array<number>}
@@ -2774,10 +2760,10 @@ export interface ViaSerializerDetails {
     'connectivity_statement_id': number;
     /**
      * 
-     * @type {TypeB60Enum}
+     * @type {ViaTypeEnum}
      * @memberof ViaSerializerDetails
      */
-    'type'?: TypeB60Enum;
+    'type'?: ViaTypeEnum;
     /**
      * 
      * @type {Array<AnatomicalEntity>}
@@ -2797,6 +2783,21 @@ export interface ViaSerializerDetails {
      */
     'are_connections_explicit': string;
 }
+
+
+/**
+ * 
+ * @export
+ * @enum {string}
+ */
+
+export const ViaTypeEnum = {
+    Axon: 'AXON',
+    Dendrite: 'DENDRITE',
+    SensoryAxon: 'SENSORY_AXON'
+} as const;
+
+export type ViaTypeEnum = typeof ViaTypeEnum[keyof typeof ViaTypeEnum];
 
 
 

--- a/frontend/src/components/Forms/StatementForm.tsx
+++ b/frontend/src/components/Forms/StatementForm.tsx
@@ -34,7 +34,7 @@ import {DestinationIcon, ViaIcon} from "../icons";
 import {ChangeRequestStatus, DestinationsGroupLabel, OriginsGroupLabel, ViasGroupLabel,} from "../../helpers/settings";
 import {Option, OptionDetail} from "../../types";
 import {composerApi as api} from "../../services/apis";
-import {ConnectivityStatement, TypeB60Enum, TypeC11Enum,} from "../../apiclient/backend";
+import {ConnectivityStatement, ViaTypeEnum, DestinationTypeEmum,} from "../../apiclient/backend";
 import {CustomFooter} from "../Widgets/HoveredOptionContent";
 import {StatementStateChip} from "../Widgets/StateChip";
 import {projections} from "../../services/ProjectionService";
@@ -297,7 +297,7 @@ const StatementForm = forwardRef((props: any, ref: React.Ref<HTMLTextAreaElement
           InputIcon: ViaIcon,
           onUpdate: async (selectedOption: string, formId: string) => {
             const viaIndex = getConnectionId(formId, statement.vias);
-            const typeOption = selectedOption as TypeB60Enum;
+            const typeOption = selectedOption as ViaTypeEnum;
 
             if (viaIndex) {
               try {
@@ -475,7 +475,7 @@ const StatementForm = forwardRef((props: any, ref: React.Ref<HTMLTextAreaElement
           await api.composerDestinationCreate({
             id: -1,
             connectivity_statement: statement.id,
-            type: TypeC11Enum.AxonT,
+            type: DestinationTypeEmum.AxonT,
             anatomical_entities: [],
             from_entities: [],
           });
@@ -504,7 +504,7 @@ const StatementForm = forwardRef((props: any, ref: React.Ref<HTMLTextAreaElement
           InputIcon: DestinationIcon,
           onUpdate: async (selectedOption: string, formId: string) => {
             const destinationIndex = getConnectionId(formId, statement?.destinations);
-            const typeOption = selectedOption as TypeC11Enum;
+            const typeOption = selectedOption as DestinationTypeEmum;
             if (destinationIndex) {
               try {
                 await api.composerDestinationPartialUpdate(destinationIndex, {

--- a/frontend/src/components/ProofingTab/GraphDiagram/Models/CustomNodeModel.tsx
+++ b/frontend/src/components/ProofingTab/GraphDiagram/Models/CustomNodeModel.tsx
@@ -1,7 +1,7 @@
 import { NodeModel, DefaultPortModel } from '@projectstorm/react-diagrams';
 import { NodeTypes } from "../GraphDiagram";
 import {CustomNodeOptions} from "../GraphDiagram";
-import { TypeC11Enum } from '../../../../apiclient/backend/api';
+import { DestinationTypeEmum } from '../../../../apiclient/backend/api';
 
 export class CustomNodeModel extends NodeModel {
     customType: NodeTypes;
@@ -34,7 +34,7 @@ export class CustomNodeModel extends NodeModel {
         }
         // Destination nodes: ports depend on the type of destination
         if (customType === NodeTypes.Destination) {
-            if (options.anatomicalType === TypeC11Enum.AfferentT) {
+            if (options.anatomicalType === DestinationTypeEmum.AfferentT) {
                 // Afferent terminals have only an out port
                 this.addPort(new DefaultPortModel(false, 'out', 'Out'));
             } else {

--- a/frontend/src/components/ProofingTab/GraphDiagram/Widgets/DestinationNodeWidget.tsx
+++ b/frontend/src/components/ProofingTab/GraphDiagram/Widgets/DestinationNodeWidget.tsx
@@ -6,7 +6,7 @@ import { CustomNodeModel } from "../Models/CustomNodeModel";
 import { DiagramEngine } from "@projectstorm/react-diagrams-core";
 import { NodeTypes } from "../GraphDiagram";
 import { ArrowDownwardIcon, ArrowOutward, DestinationIcon, OriginIcon, ViaIcon } from "./icons";
-import { TypeC11Enum } from "../../../../apiclient/backend";
+import { DestinationTypeEmum } from "../../../../apiclient/backend";
 
 interface DestinationNodeProps {
     model: CustomNodeModel;
@@ -36,7 +36,7 @@ export const DestinationNodeWidget: React.FC<DestinationNodeProps> = ({
     // Determine if the node is an afferent terminal
     const isAfferentTerminal =
         model.getOptions().anatomicalType ===
-        TypeC11Enum.AfferentT;
+        DestinationTypeEmum.AfferentT;
 
     const handleDoubleClick = () => {
         valueRef.current = !valueRef.current;
@@ -401,7 +401,7 @@ const NonAfferentTerminalDetails: React.FC<{ model: CustomNodeModel }> = ({
                     {model.getOptions().uri}
                 </Typography>
                 <Chip
-                    label={model.getOptions().anatomicalType === TypeC11Enum.AxonT ? "Axon Terminal" : "Not Specified"}
+                    label={model.getOptions().anatomicalType === DestinationTypeEmum.AxonT ? "Axon Terminal" : "Not Specified"}
                     variant="outlined"
                     color="secondary"
                     sx={{

--- a/frontend/src/components/ProofingTab/GraphDiagram/Widgets/ViaNodeWidget.tsx
+++ b/frontend/src/components/ProofingTab/GraphDiagram/Widgets/ViaNodeWidget.tsx
@@ -8,7 +8,7 @@ import Chip from "@mui/material/Chip";
 import { CustomNodeModel } from "../Models/CustomNodeModel";
 import { DiagramEngine } from "@projectstorm/react-diagrams-core";
 import { NodeTypes } from "../GraphDiagram";
-import { TypeB60Enum } from "../../../../apiclient/backend";
+import { ViaTypeEnum } from "../../../../apiclient/backend";
 
 
 interface ViaNodeProps {
@@ -237,7 +237,7 @@ export const ViaNodeWidget: React.FC<ViaNodeProps> = ({ model, engine }) => {
                             {model.getOptions().uri}
                         </Typography>
                         <Chip
-                            label={model.getOptions().anatomicalType === TypeB60Enum.Axon ? "Axon" : "Dendrite"}
+                            label={model.getOptions().anatomicalType === ViaTypeEnum.Axon ? "Axon" : "Dendrite"}
                             variant="filled"
                             sx={{
                                 background: "#F2F2FC",

--- a/frontend/src/services/GraphDiagramService.ts
+++ b/frontend/src/services/GraphDiagramService.ts
@@ -3,15 +3,15 @@ import {
   AnatomicalEntity,
   ViaSerializerDetails,
   DestinationSerializerDetails,
-  TypeC11Enum,
+  DestinationTypeEmum,
 } from "../apiclient/backend";
 import { CustomNodeModel } from "../components/ProofingTab/GraphDiagram/Models/CustomNodeModel";
 import { CustomNodeOptions, NodeTypes } from "../components/ProofingTab/GraphDiagram/GraphDiagram";
 
-export const DestinationTypeMapping: Record<TypeC11Enum, string> = {
-  [TypeC11Enum.AxonT]: 'Axon terminal',
-  [TypeC11Enum.AfferentT]: 'Afferent terminal',
-  [TypeC11Enum.Unknown]: 'Not specified'
+export const DestinationTypeMapping: Record<DestinationTypeEmum, string> = {
+  [DestinationTypeEmum.AxonT]: 'Axon terminal',
+  [DestinationTypeEmum.AfferentT]: 'Afferent terminal',
+  [DestinationTypeEmum.Unknown]: 'Not specified'
 };
 
 interface EntityInfo {
@@ -59,7 +59,7 @@ export const processData = ({
   const afferentTerminalIds = [...entityMap.entries()]
     .filter(
       ([_, info]) =>
-        info.nodeType === NodeTypes.Destination && info.anatomicalType === TypeC11Enum.AfferentT
+        info.nodeType === NodeTypes.Destination && info.anatomicalType === DestinationTypeEmum.AfferentT
     )
     .map(([id, _]) => id);
 
@@ -67,7 +67,7 @@ export const processData = ({
   const nonAfferentDestinationIds = [...entityMap.entries()]
     .filter(
       ([_, info]) =>
-        info.nodeType === NodeTypes.Destination && info.anatomicalType !== TypeC11Enum.AfferentT
+        info.nodeType === NodeTypes.Destination && info.anatomicalType !== DestinationTypeEmum.AfferentT
     )
     .map(([id, _]) => id);
 

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2621,7 +2621,7 @@ components:
         connectivity_statement:
           type: integer
         type:
-          $ref: '#/components/schemas/TypeC11Enum'
+          $ref: '#/components/schemas/DestinationTypeEmum'
         anatomical_entities:
           type: array
           items:
@@ -2644,7 +2644,7 @@ components:
           type: integer
           readOnly: true
         type:
-          $ref: '#/components/schemas/TypeC11Enum'
+          $ref: '#/components/schemas/DestinationTypeEmum'
         anatomical_entities:
           type: array
           items:
@@ -2662,6 +2662,12 @@ components:
       - connectivity_statement_id
       - from_entities
       - id
+    DestinationTypeEmum:
+      enum:
+      - AXON-T
+      - AFFERENT-T
+      - UNKNOWN
+      type: string
     GraphState:
       type: object
       properties:
@@ -3363,7 +3369,7 @@ components:
         connectivity_statement:
           type: integer
         type:
-          $ref: '#/components/schemas/TypeC11Enum'
+          $ref: '#/components/schemas/DestinationTypeEmum'
         anatomical_entities:
           type: array
           items:
@@ -3495,7 +3501,7 @@ components:
         connectivity_statement:
           type: integer
         type:
-          $ref: '#/components/schemas/TypeB60Enum'
+          $ref: '#/components/schemas/ViaTypeEnum'
         anatomical_entities:
           type: array
           items:
@@ -3831,17 +3837,6 @@ components:
       required:
       - id
       - tag
-    TypeB60Enum:
-      enum:
-      - AXON
-      - DENDRITE
-      type: string
-    TypeC11Enum:
-      enum:
-      - AXON-T
-      - AFFERENT-T
-      - UNKNOWN
-      type: string
     User:
       type: object
       description: User
@@ -3885,7 +3880,7 @@ components:
         connectivity_statement:
           type: integer
         type:
-          $ref: '#/components/schemas/TypeB60Enum'
+          $ref: '#/components/schemas/ViaTypeEnum'
         anatomical_entities:
           type: array
           items:
@@ -3910,7 +3905,7 @@ components:
           type: integer
           readOnly: true
         type:
-          $ref: '#/components/schemas/TypeB60Enum'
+          $ref: '#/components/schemas/ViaTypeEnum'
         anatomical_entities:
           type: array
           items:
@@ -3929,6 +3924,12 @@ components:
       - from_entities
       - id
       - order
+    ViaTypeEnum:
+      enum:
+      - AXON
+      - DENDRITE
+      - SENSORY_AXON
+      type: string
   securitySchemes:
     basicAuth:
       type: http


### PR DESCRIPTION
- Uses [ENUM_NAME_OVERRIDES](https://drf-spectacular.readthedocs.io/en/latest/faq.html#i-get-warnings-regarding-my-enum-or-my-enum-names-have-a-weird-suffix) to specify the enum names.
- Updates frontend imports to use the new enum names