### PR TITLE
SCKAN-404 feat: Update update connectivity statement command

### DIFF
--- a/backend/composer/management/commands/update_connectivity_statement_field.py
+++ b/backend/composer/management/commands/update_connectivity_statement_field.py
@@ -1,8 +1,8 @@
+import importlib
 import time
 
 from django.core.management.base import BaseCommand
 from composer.services.cs_ingestion.neurondm_new_field_ingestion_service import ingest_neurondm_new_field_to_statements
-
 
 class Command(BaseCommand):
     help = "Updates composer statements field with neurondm property"
@@ -28,23 +28,45 @@ class Command(BaseCommand):
             required=True,
             help='The field name in Neurondm to ingest.',
         )
+        parser.add_argument(
+            '--skip_validation',
+            action='store_true',
+            help='Skip model validation when updating the field.',
+        )
+        parser.add_argument('--transform_fn', type=str, help='A Python function to apply to the field. Example: "composer.services.cs_ingestion.helpers.getters.get_or_create_populationset".')
+
 
     def handle(self, *args, **options):
-        full_imports = options['full_imports']
-        label_imports = options['label_imports']
+        full_imports = options.get('full_imports', [])
+        label_imports = options.get('label_imports', [])
         cs_field = options['cs_field']
         neurondm_field = options['neurondm_field']
+        skip_validation = options['skip_validation']
+        transform_fn_path = options.get('transform_fn')
+
+        # Dynamically import the function if provided
+        transform_fn = None
+        if transform_fn_path:
+            try:
+                module_name, function_name = transform_fn_path.rsplit(".", 1)
+                module = importlib.import_module(module_name)
+                transform_fn = getattr(module, function_name)
+            except (ImportError, AttributeError) as e:
+                self.stdout.write(self.style.ERROR(f"Error loading transform function '{transform_fn_path}': {e}"))
+                return
 
         start_time = time.time()
         try:
             ingest_neurondm_new_field_to_statements(
-                neurondm_field, cs_field, full_imports, label_imports)
+                neurondm_field, cs_field, full_imports, label_imports, skip_validation, transform_fn
+            )
         except Exception as e:
             self.stdout.write(self.style.ERROR(f"Error during ingestion: {e}"))
             return
-        end_time = time.time()
 
+        end_time = time.time()
         duration = end_time - start_time
 
         self.stdout.write(self.style.SUCCESS(
-            f"Ingestion for {cs_field} from Neurondm {neurondm_field} completed in {duration:.2f} seconds."))
+            f"Ingestion for {cs_field} from Neurondm {neurondm_field} completed in {duration:.2f} seconds."
+        ))

--- a/backend/composer/models.py
+++ b/backend/composer/models.py
@@ -841,7 +841,7 @@ class ConnectivityStatement(models.Model, BulkActionMixin):
             )
             if (
                 original_population is not None
-                and original_population != self.population.id
+                and original_population != (self.population.id if self.population else None)
             ):
                 raise ValidationError(
                     "Cannot change population set after the statement has been exported."

--- a/backend/composer/services/cs_ingestion/neurondm_new_field_ingestion_service.py
+++ b/backend/composer/services/cs_ingestion/neurondm_new_field_ingestion_service.py
@@ -12,21 +12,37 @@ def check_if_connectivity_statement_field_exists(cs_field):
 	except FieldDoesNotExist:
 		raise ValueError(f"Field '{cs_field}' does not exist in ConnectivityStatement model.")
 
-def ingest_neurondm_new_field_to_statements(neurondm_field, cs_field, full_imports=[], label_imports=[]):
-	check_if_connectivity_statement_field_exists(cs_field)
-	
-	statements_list = get_statements_from_neurondm(
-            full_imports=full_imports, label_imports=label_imports, logger_service_param=logger_service)
-	for statement in statements_list:
-		try:
-			if neurondm_field not in statement:
-				raise KeyError(f"Field '{neurondm_field}' not found in neurondm.")
-			connectivity_statement = ConnectivityStatement.objects.get(
-				reference_uri=statement[ID])
-			setattr(connectivity_statement, cs_field,
-			        statement[neurondm_field])
-			connectivity_statement.save(update_fields=[cs_field])
-		except ConnectivityStatement.DoesNotExist:
-			pass	
-		except KeyError as e:
-			raise 
+def ingest_neurondm_new_field_to_statements(
+    neurondm_field, cs_field, full_imports=[], label_imports=[], skip_validation=False, transform_fn=None
+):
+    check_if_connectivity_statement_field_exists(cs_field)
+
+    statements_list = get_statements_from_neurondm(
+        full_imports=full_imports, label_imports=label_imports, logger_service_param=logger_service
+    )
+
+    for statement in statements_list:
+        try:
+            if neurondm_field not in statement:
+                raise KeyError(f"Field '{neurondm_field}' not found in neurondm.")
+            
+            connectivity_statement = ConnectivityStatement.objects.get(reference_uri=statement[ID])
+            value = statement[neurondm_field]
+
+            # Apply transformation if a function is provided
+            if transform_fn:
+                try:
+                    value = transform_fn(value)
+                except Exception as e:
+                    raise ValueError(f"Error applying transformation function '{transform_fn.__name__}': {e}")
+
+            if skip_validation:
+                ConnectivityStatement.objects.filter(id=connectivity_statement.id).update(**{cs_field: value})
+            else:
+                setattr(connectivity_statement, cs_field, value)
+                connectivity_statement.save(update_fields=[cs_field])
+                
+        except ConnectivityStatement.DoesNotExist:
+            pass
+        except KeyError as e:
+            raise


### PR DESCRIPTION
Potentially closes: https://metacell.atlassian.net/browse/SCKAN-404

- Updates update_connectivity_statement_field to allow transforms and skip model validation.
- Fixes small bug on population set validation on save

Running:

`python manage.py update_connectivity_statement_field --cs_field population --neurondm_field populationset --skip_validation --transform_fn composer.services.cs_ingestion.helpers.getters.get_or_create_populationset`

Should update all connectivity statements with the populationset defined by neurondm independently of the statement condition