### PR TITLE
SCKAN-411 - update anatomicalType label in ViaNodeWidget to include 'Axon to PNS'

### DIFF
--- a/frontend/src/components/ProofingTab/GraphDiagram/Widgets/ViaNodeWidget.tsx
+++ b/frontend/src/components/ProofingTab/GraphDiagram/Widgets/ViaNodeWidget.tsx
@@ -237,7 +237,11 @@ export const ViaNodeWidget: React.FC<ViaNodeProps> = ({ model, engine }) => {
                             {model.getOptions().uri}
                         </Typography>
                         <Chip
-                            label={model.getOptions().anatomicalType === ViaTypeEnum.Axon ? "Axon" : "Dendrite"}
+                            label={
+                                model.getOptions().anatomicalType === ViaTypeEnum.Axon
+                                    ? "Axon" : model.getOptions().anatomicalType === ViaTypeEnum.Dendrite
+                                        ? "Dendrite" : "Axon to PNS"
+                            }
                             variant="filled"
                             sx={{
                                 background: "#F2F2FC",


### PR DESCRIPTION

I changed some of the vias type in the demo data to make them sensory axon
```jsx

[via.type for via in cs.via_set.all()]
['SENSORY_AXON', 'SENSORY_AXON', 'SENSORY_AXON', 'SENSORY_AXON', 'AXON', 'AXON', 'SENSORY_AXON', 'SENSORY_AXON', 'SENSORY_AXON']
```

Demo of how it looks 
![image](https://github.com/user-attachments/assets/b4a996f3-454b-4394-9e2a-a89461d4e26f)
