### PR TITLE
Feature/s ck an 422

### DIFF
--- a/backend/composer/models.py
+++ b/backend/composer/models.py
@@ -785,7 +785,8 @@ class ConnectivityStatement(models.Model, BulkActionMixin):
         permission=ConnectivityStatementStateService.has_permission_to_transition_to_invalid,
     )
     def invalid(self, *args, **kwargs):
-        ...
+        self.has_statement_been_exported = True
+        self.save(update_fields = ["has_statement_been_exported"])
 
     @transition(
         field=state,

--- a/backend/composer/signals.py
+++ b/backend/composer/signals.py
@@ -217,10 +217,21 @@ def sentence_and_cs_tags_changed(sender, instance, action, **kwargs):
 @receiver(post_save, sender=Note, dispatch_uid="note_post_save")
 @receiver(post_delete, sender=Note, dispatch_uid="note_post_delete")
 def note_post_save_and_delete(sender, instance, **kwargs):
-    if instance.sentence:
-        update_modified_date(instance.sentence)
-    if instance.connectivity_statement:
-        update_modified_date(instance.connectivity_statement)
+    try:
+        sentence = instance.sentence
+    except Sentence.DoesNotExist:
+        sentence = None
+
+    if sentence:
+        update_modified_date(sentence)
+    try:
+        cs = instance.connectivity_statement
+    except ConnectivityStatement.DoesNotExist:
+        cs = None
+
+    if cs:
+        update_modified_date(cs)
+
 
 
 @receiver(


### PR DESCRIPTION
Closes https://metacell.atlassian.net/browse/SCKAN-422

- Sets has_statement_been_exported on transitions to invalid

Newly ingested invalid statement:
![image](https://github.com/user-attachments/assets/34688e68-a0c0-4e5b-a491-13766871d223)


Misc:
- Fixes a bug with a note signal that was preventing the deletion of connectivity statements 