### PR TITLE
Feature/esckan-102 - Extend Composer public endpoint to serve Exported AND Npo_Approved records

### DIFF
--- a/backend/composer/api/views.py
+++ b/backend/composer/api/views.py
@@ -14,7 +14,7 @@ from rest_framework import generics
 from django_filters.rest_framework import DjangoFilterBackend
 from django.db.models import Case, When, Value, IntegerField
 from composer.services import bulk_service
-from composer.enums import BulkActionType
+from composer.enums import BulkActionType, CSState
 from composer.services.state_services import (
     ConnectivityStatementStateService,
     SentenceStateService,
@@ -426,7 +426,6 @@ class AnatomicalEntityViewSet(viewsets.ReadOnlyModelViewSet):
     filterset_class = AnatomicalEntityFilter
 
 
-
 class PhenotypeViewSet(viewsets.ReadOnlyModelViewSet):
     """
     Phenotype
@@ -596,7 +595,9 @@ class KnowledgeStatementViewSet(
     """
 
     model = ConnectivityStatement
-    queryset = ConnectivityStatement.objects.exported()
+    queryset = ConnectivityStatement.objects.filter(
+        state__in=[CSState.NPO_APPROVED, CSState.EXPORTED]
+    )
     serializer_class = KnowledgeStatementSerializer
     permission_classes = [
         permissions.AllowAny,
@@ -612,7 +613,8 @@ class KnowledgeStatementViewSet(
         return KnowledgeStatementSerializer
 
     def list(self, request, *args, **kwargs):
-        return super().list(request, *args, **kwargs)
+        response = super().list(request, *args, **kwargs)
+        return response
 
 
 class TagViewSet(viewsets.ReadOnlyModelViewSet):


### PR DESCRIPTION
Jira link - https://metacell.atlassian.net/browse/ESCKAN-102

Task description:
1. Extending the Public endpoint to also include the NPO_APPROVED statements (along with exported ones). In the response - one can distinguish between the two - by a new attribute - "state" - which tells you whether the status is "NPO_APPROVED" or "EXPORTED".
2. Extending the serializer in the public knowledge_statements API - to include - curie_id, populationset (aka population), alerts. You can see the extended information in the response in the below image



New addition to the response in the knowledge_statements public endpoint
![image](https://github.com/user-attachments/assets/3e725167-9709-4b61-a8ed-e789fe499099)





Now the response also includes the NPO_APPROVED 
![image](https://github.com/user-attachments/assets/c464bbb0-8a37-492d-8d58-c5c44fab405f)





