### PR TITLE
SCKAN-443 feat: Add population_file param to ingest_statements

### DIFF
--- a/applications/composer/backend/composer/management/commands/ingest_statements.py
+++ b/applications/composer/backend/composer/management/commands/ingest_statements.py
@@ -49,11 +49,11 @@ class Command(BaseCommand):
         population_file = options['population_file']
 
         # Read population URIs from file if provided
-        population_uris = []
+        population_uris = set()
         if population_file:
             try:
                 with open(population_file, 'r') as f:
-                    population_uris = [line.strip() for line in f if line.strip()]
+                    population_uris = set(line.strip() for line in f if line.strip())
                 self.stdout.write(f"Loaded {len(population_uris)} population URIs from {population_file}")
             except FileNotFoundError:
                 self.stderr.write(self.style.ERROR(f"Population file not found: {population_file}"))

--- a/applications/composer/backend/composer/management/commands/ingest_statements.py
+++ b/applications/composer/backend/composer/management/commands/ingest_statements.py
@@ -34,6 +34,11 @@ class Command(BaseCommand):
             nargs='*',
             help='List of label imports to include in the ingestion.',
         )
+        parser.add_argument(
+            '--population_file',
+            type=str,
+            help='Path to a text file containing population URIs (one per line) that should be updated regardless of their status.',
+        )
 
     def handle(self, *args, **options):
         update_upstream = options['update_upstream']
@@ -41,10 +46,25 @@ class Command(BaseCommand):
         disable_overwrite = options['disable_overwrite']
         full_imports = options['full_imports']
         label_imports = options['label_imports']
+        population_file = options['population_file']
+
+        # Read population URIs from file if provided
+        population_uris = []
+        if population_file:
+            try:
+                with open(population_file, 'r') as f:
+                    population_uris = [line.strip() for line in f if line.strip()]
+                self.stdout.write(f"Loaded {len(population_uris)} population URIs from {population_file}")
+            except FileNotFoundError:
+                self.stderr.write(self.style.ERROR(f"Population file not found: {population_file}"))
+                return
+            except Exception as e:
+                self.stderr.write(self.style.ERROR(f"Error reading population file: {e}"))
+                return
 
         start_time = time.time()
 
-        ingest_statements(update_upstream, update_anatomical_entities, disable_overwrite, full_imports, label_imports)
+        ingest_statements(update_upstream, update_anatomical_entities, disable_overwrite, full_imports, label_imports, population_uris)
 
         end_time = time.time()
 

--- a/applications/composer/backend/composer/management/commands/ingest_statements.py
+++ b/applications/composer/backend/composer/management/commands/ingest_statements.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
         parser.add_argument(
             '--population_file',
             type=str,
-            help='Path to a text file containing population URIs (one per line) that should be updated regardless of their status.',
+            help='Path to a text file containing population URIs (one per line). When provided, ONLY statements matching these URIs will be processed for ingestion.',
         )
 
     def handle(self, *args, **options):
@@ -49,7 +49,7 @@ class Command(BaseCommand):
         population_file = options['population_file']
 
         # Read population URIs from file if provided
-        population_uris = set()
+        population_uris = None
         if population_file:
             try:
                 with open(population_file, 'r', encoding='utf-8') as f:

--- a/applications/composer/backend/composer/services/cs_ingestion/cs_ingestion_services.py
+++ b/applications/composer/backend/composer/services/cs_ingestion/cs_ingestion_services.py
@@ -32,7 +32,7 @@ def ingest_statements(
 ):
 
     if population_uris is None:
-        population_uris = []
+        population_uris = set()
 
     statements_list = get_statements_from_neurondm(
         full_imports=full_imports,

--- a/applications/composer/backend/composer/services/cs_ingestion/cs_ingestion_services.py
+++ b/applications/composer/backend/composer/services/cs_ingestion/cs_ingestion_services.py
@@ -28,7 +28,11 @@ def ingest_statements(
     disable_overwrite=False,
     full_imports=[],
     label_imports=[],
+    population_uris=None,
 ):
+
+    if population_uris is None:
+        population_uris = []
 
     statements_list = get_statements_from_neurondm(
         full_imports=full_imports,
@@ -37,7 +41,7 @@ def ingest_statements(
         statement_alert_uris=set(AlertType.objects.values_list("uri", flat=True)),
     )
     overridable_and_new_statements = get_overwritable_and_new_statements(
-        statements_list, disable_overwrite
+        statements_list, disable_overwrite, population_uris
     )
     statements = validate_statements(
         overridable_and_new_statements, update_anatomical_entities

--- a/applications/composer/backend/composer/services/cs_ingestion/helpers/overwritable_helper.py
+++ b/applications/composer/backend/composer/services/cs_ingestion/helpers/overwritable_helper.py
@@ -1,4 +1,4 @@
-from typing import List, Any, Dict
+from typing import List, Any, Dict, Set, Union
 
 from composer.enums import CSState, SentenceState
 from composer.models import Sentence, ConnectivityStatement
@@ -10,9 +10,9 @@ from composer.services.cs_ingestion.models import LoggableAnomaly
 logger_service = LoggerService()
 
 
-def get_overwritable_and_new_statements(statements_list: List[Dict[str, Any]], disable_overwrite: bool=False, population_uris: List[str]=None) -> List[Dict[str, Any]]:
+def get_overwritable_and_new_statements(statements_list: List[Dict[str, Any]], disable_overwrite: bool=False, population_uris: Union[List[str], Set[str]]=None) -> List[Dict[str, Any]]:
     if population_uris is None:
-        population_uris = []
+        population_uris = set()
     
     overwritable_and_new_statements = [
         statement for statement in statements_list
@@ -34,13 +34,13 @@ def is_new_or_overwritable_sentence(statement: Dict, disable_overwrite: bool) ->
     return can_sentence_be_overwritten(sentence, statement)
 
 
-def is_new_or_overwritable_statement(statement: Dict, disable_overwrite: bool, population_uris: List[str]=None) -> bool:
+def is_new_or_overwritable_statement(statement: Dict, disable_overwrite: bool, population_uris: Union[List[str], Set[str]]=None) -> bool:
     """
     If disable_overwrite is True, then the statement is considered invalid for overwriting - if it already exists in the database.
     However, statements with URIs in population_uris should be updatable regardless of their status (unless disable_overwrite is True).
     """
     if population_uris is None:
-        population_uris = []
+        population_uris = set()
     
     statement_uri = statement[ID]
     
@@ -51,7 +51,7 @@ def is_new_or_overwritable_statement(statement: Dict, disable_overwrite: bool, p
         if disable_overwrite:
             return False
             
-        # If the statement URI is in the population_uris list, it should be updatable regardless of status
+        # If the statement URI is in the population_uris set, it should be updatable regardless of status
         if statement_uri in population_uris:
             return True
             

--- a/applications/composer/backend/composer/services/cs_ingestion/helpers/overwritable_helper.py
+++ b/applications/composer/backend/composer/services/cs_ingestion/helpers/overwritable_helper.py
@@ -10,10 +10,13 @@ from composer.services.cs_ingestion.models import LoggableAnomaly
 logger_service = LoggerService()
 
 
-def get_overwritable_and_new_statements(statements_list: List[Dict[str, Any]], disable_overwrite: bool=False) -> List[Dict[str, Any]]:
+def get_overwritable_and_new_statements(statements_list: List[Dict[str, Any]], disable_overwrite: bool=False, population_uris: List[str]=None) -> List[Dict[str, Any]]:
+    if population_uris is None:
+        population_uris = []
+    
     overwritable_and_new_statements = [
         statement for statement in statements_list
-        if is_new_or_overwritable_statement(statement, disable_overwrite)
+        if is_new_or_overwritable_statement(statement, disable_overwrite, population_uris)
     ]
     return overwritable_and_new_statements
 
@@ -31,16 +34,30 @@ def is_new_or_overwritable_sentence(statement: Dict, disable_overwrite: bool) ->
     return can_sentence_be_overwritten(sentence, statement)
 
 
-def is_new_or_overwritable_statement(statement: Dict, disable_overwrite: bool) -> bool:
+def is_new_or_overwritable_statement(statement: Dict, disable_overwrite: bool, population_uris: List[str]=None) -> bool:
     """
     If disable_overwrite is True, then the statement is considered invalid for overwriting - if it already exists in the database.
+    However, statements with URIs in population_uris should be updatable regardless of their status (unless disable_overwrite is True).
     """
+    if population_uris is None:
+        population_uris = []
+    
+    statement_uri = statement[ID]
+    
     try:
-        connectivity_statement = ConnectivityStatement.objects.get(reference_uri=statement[ID])
+        connectivity_statement = ConnectivityStatement.objects.get(reference_uri=statement_uri)
+        
+        # If disable_overwrite is True, then no overwrites should happen, not even the ones from the population file
         if disable_overwrite:
             return False
+            
+        # If the statement URI is in the population_uris list, it should be updatable regardless of status
+        if statement_uri in population_uris:
+            return True
+            
     except ConnectivityStatement.DoesNotExist:
         return True
+    
     return can_statement_be_overwritten(connectivity_statement, statement)
 
 


### PR DESCRIPTION
Closes https://metacell.atlassian.net/browse/SCKAN-443

- Adds a new population_file optional argument to the ingest statements command (expects it to be a filepath to a file that stores population ids, 1 per line.
- Updates ingestion service to consider populations with the id in the population_file as can_be_overwritten, independently of their state.
- Adds proper unit tests for this specific feature

https://github.com/user-attachments/assets/20d92a41-9e45-4480-8f7c-523abdf7f45e

