### PR TITLE
SCKAN-434 fix: Make doi regex more rigid

### DIFF
--- a/applications/composer/backend/composer/models.py
+++ b/applications/composer/backend/composer/models.py
@@ -102,10 +102,10 @@ def validate_provenance_uri(value):
     
     # DOI patterns
     doi_patterns = [
-        r'^10\.\d{4,}/[^\s]+$',  # Standard DOI format
-        r'^doi:10\.\d{4,}/[^\s]+$',  # DOI with prefix
-        r'^https?://doi\.org/10\.\d{4,}/[^\s]+$',  # DOI URL
-        r'^https?://dx\.doi\.org/10\.\d{4,}/[^\s]+$',  # Alternative DOI URL
+        r'^10\.\d{4,}/[a-zA-Z0-9\-._():]+(?:/[a-zA-Z0-9\-._():]+)*$',  # Standard DOI format - no consecutive slashes
+        r'^doi:10\.\d{4,}/[a-zA-Z0-9\-._():]+(?:/[a-zA-Z0-9\-._():]+)*$',  # DOI with prefix
+        r'^https?://doi\.org/10\.\d{4,}/[a-zA-Z0-9\-._():]+(?:/[a-zA-Z0-9\-._():]+)*$',  # DOI URL
+        r'^https?://dx\.doi\.org/10\.\d{4,}/[a-zA-Z0-9\-._():]+(?:/[a-zA-Z0-9\-._():]+)*$',  # Alternative DOI URL
     ]
     
     # PMID patterns
@@ -121,8 +121,8 @@ def validate_provenance_uri(value):
         r'^https?://www\.ncbi\.nlm\.nih\.gov/pmc/articles/PMC\d+/?$',  # PMC URL
     ]
     
-    # URL pattern (comprehensive)
-    url_pattern = r'^https?://(?:[-\w.])+(?:[:\d]+)?(?:/(?:[\w/_.])*(?:\?(?:[\w&=%.])*)?(?:#(?:[\w.])*)?)?$'
+    # URL pattern
+    url_pattern = r'^https?://[a-zA-Z0-9\-.]+(:[0-9]+)?(/[a-zA-Z0-9\-._~!$&\'()*+,;=:@]+)*(\?[a-zA-Z0-9\-._~!$&\'()*+,;=:@/?]*)?(\#[a-zA-Z0-9\-._~!$&\'()*+,;=:@/?]*)?$'
     
     # Check if it matches any of the valid patterns
     all_patterns = doi_patterns + pmid_patterns + pmcid_patterns + [url_pattern]

--- a/applications/composer/frontend/src/components/Forms/ProvenanceForm.tsx
+++ b/applications/composer/frontend/src/components/Forms/ProvenanceForm.tsx
@@ -71,10 +71,10 @@ const ProvenancesForm = (props: any) => {
     
     // DOI patterns
     const doiPatterns = [
-      /^10\.\d{4,}\/[^\s]+$/,  // Standard DOI format
-      /^doi:10\.\d{4,}\/[^\s]+$/i,  // DOI with prefix
-      /^https?:\/\/doi\.org\/10\.\d{4,}\/[^\s]+$/i,  // DOI URL
-      /^https?:\/\/dx\.doi\.org\/10\.\d{4,}\/[^\s]+$/i,  // Alternative DOI URL
+      /^10\.\d{4,}\/[a-zA-Z0-9\-._():]+(?:\/[a-zA-Z0-9\-._():]+)*$/,  // Standard DOI format - no consecutive slashes
+      /^doi:10\.\d{4,}\/[a-zA-Z0-9\-._():]+(?:\/[a-zA-Z0-9\-._():]+)*$/i,  // DOI with prefix
+      /^https?:\/\/doi\.org\/10\.\d{4,}\/[a-zA-Z0-9\-._():]+(?:\/[a-zA-Z0-9\-._():]+)*$/i,  // DOI URL
+      /^https?:\/\/dx\.doi\.org\/10\.\d{4,}\/[a-zA-Z0-9\-._():]+(?:\/[a-zA-Z0-9\-._():]+)*$/i,  // Alternative DOI URL
     ];
     
     // PMID patterns
@@ -90,8 +90,8 @@ const ProvenancesForm = (props: any) => {
       /^https?:\/\/www\.ncbi\.nlm\.nih\.gov\/pmc\/articles\/PMC\d+\/?$/i,  // PMC URL
     ];
     
-    // URL pattern (comprehensive)
-    const urlPattern = /^https?:\/\/(?:[-\w.])+(?::\d+)?(?:\/(?:[\w/_.])*(?:\?(?:[\w&=%.])*)?(?:#(?:[\w.])*)?)?$/i;
+    // URL pattern
+    const urlPattern = /^https?:\/\/[a-zA-Z0-9\-.]+(?::[0-9]+)?(?:\/[a-zA-Z0-9\-._~!$&'()*+,;=:@]+)*(?:\?[a-zA-Z0-9\-._~!$&'()*+,;=:@\/?]*)?(?:\#[a-zA-Z0-9\-._~!$&'()*+,;=:@\/?]*)?$/i;
     
     // Check if it matches any of the valid patterns
     const allPatterns = [...doiPatterns, ...pmidPatterns, ...pmcidPatterns, urlPattern];


### PR DESCRIPTION
Closes https://metacell.atlassian.net/browse/SCKAN-434?focusedCommentId=24111

As far as I'm aware there's no perfect regex to match doi so it's possible that we can still have some invalid ones; with that said, I updated the regex to be a bit more rigid and specifically prevent double slashes

<img width="1551" height="229" alt="image" src="https://github.com/user-attachments/assets/24fa8d17-8523-4ba0-ac61-0c85138c45da" />
