### PR TITLE
SCKAN-443 fea: Prevent transitions when population uri is provided

### DIFF
--- a/applications/composer/backend/composer/management/commands/ingest_statements.py
+++ b/applications/composer/backend/composer/management/commands/ingest_statements.py
@@ -64,10 +64,13 @@ class Command(BaseCommand):
 
         start_time = time.time()
 
-        ingest_statements(update_upstream, update_anatomical_entities, disable_overwrite, full_imports, label_imports, population_uris)
+        success = ingest_statements(update_upstream, update_anatomical_entities, disable_overwrite, full_imports, label_imports, population_uris)
 
         end_time = time.time()
 
         duration = end_time - start_time
 
-        self.stdout.write(self.style.SUCCESS(f"Ingestion completed in {duration:.2f} seconds."))
+        if success:
+            self.stdout.write(self.style.SUCCESS(f"Ingestion completed successfully in {duration:.2f} seconds."))
+        else:
+            self.stderr.write(self.style.ERROR(f"Ingestion failed after {duration:.2f} seconds. Check logs for details."))

--- a/applications/composer/backend/composer/services/cs_ingestion/cs_ingestion_services.py
+++ b/applications/composer/backend/composer/services/cs_ingestion/cs_ingestion_services.py
@@ -48,13 +48,17 @@ def ingest_statements(
         overridable_and_new_statements, update_anatomical_entities
     )
 
+    # When population_uris is provided (i.e., a population file was used),
+    # skip state transitions to preserve existing statement states
+    skip_state_transitions = population_uris is not None
+
     successful_transaction = True
     try:
         with transaction.atomic():
             for statement in statements:
                 sentence, _ = get_or_create_sentence(statement)
                 create_or_update_connectivity_statement(
-                    statement, sentence, update_anatomical_entities, logger_service
+                    statement, sentence, update_anatomical_entities, logger_service, skip_state_transitions
                 )
 
             update_forward_connections(statements)
@@ -77,3 +81,5 @@ def ingest_statements(
         if update_upstream:
             update_upstream_statements()
         logger_service.write_ingested_statements_to_file(statements)
+    
+    return successful_transaction

--- a/applications/composer/backend/tests/test_ingest_statements_e2e.py
+++ b/applications/composer/backend/tests/test_ingest_statements_e2e.py
@@ -1,0 +1,95 @@
+from unittest.mock import patch
+from composer.services.cs_ingestion.cs_ingestion_services import ingest_statements
+from composer.models import ConnectivityStatement
+from composer.services.cs_ingestion.neurondm_script import log_error
+from composer.services.cs_ingestion.models import NeuronDMOrigin, NeuronDMDestination, NeuronDMVia, ValidationErrors
+from composer.enums import CSState
+from django.db.models import Q
+from django.test import TestCase
+
+
+class TestIngestStatements(TestCase):
+    # """
+    # NOTE:
+    # This test depends on the directory system of the Scicrunch neurondm - here - https://raw.githubusercontent.com/SciCrunch/NIF-Ontology/neurons/**/*.ttl
+    # Check more details in neurondm_script.py
+    # """
+
+    def flush_connectivity_statements(self):
+        ConnectivityStatement.objects.all().delete()
+
+    def test_ingestion_with_invalid_imports(self):
+        self.flush_connectivity_statements()
+        self.assertEqual(ConnectivityStatement.objects.count(), 0)
+        ingest_statements(full_imports=['full'], label_imports=['label'])
+        self.assertEqual(ConnectivityStatement.objects.count(), 0)
+
+    def test_ingestion_with_valid_label_and_invalid_full_imports(self):
+        ingest_statements(
+            full_imports=['full'],
+            label_imports=['apinatomy-neuron-populations']
+        )
+        self.assertEqual(ConnectivityStatement.objects.count(), 0)
+        self.flush_connectivity_statements()
+
+    def test_ingestion_with_valid_full_and_invalid_label_imports(self):
+        ingest_statements(full_imports=['sparc-nlp'], label_imports=['label'])
+        self.assertNotEqual(ConnectivityStatement.objects.count(), 0)
+        self.flush_connectivity_statements()
+
+    def test_ingestion_with_valid_imports(self):
+        ingest_statements(
+            full_imports=['sparc-nlp'],
+            label_imports=['apinatomy-neuron-populations']
+        )
+        self.assertNotEqual(ConnectivityStatement.objects.count(), 0)
+        self.flush_connectivity_statements()
+
+    def test_ingestion_without_passing_full_imports(self):
+        # don't pass the full import and it will still work - by utilizing the defaults
+        self.flush_connectivity_statements()
+        ingest_statements(label_imports=['apinatomy-neuron-populations'])
+        self.assertNotEqual(ConnectivityStatement.objects.count(), 0)
+
+    def test_ingestion_without_passing_label_imports(self):
+        # don't pass the label import and it will still work - by utilizing the defaults
+        self.flush_connectivity_statements()
+        ingest_statements(full_imports=['sparc-nlp'])
+        self.assertNotEqual(ConnectivityStatement.objects.count(), 0)
+
+    def test_disable_overwrite_for_statements(self):
+        self.flush_connectivity_statements()
+        ingest_statements(full_imports=['sparc-nlp'])
+
+        NEW_KNOWLEDGE_STATEMENT = "This is a new knowledge statement"
+
+        # Edit the statement that is in EXPORTED or in INVALID state to check if that is overwritten
+        # Other states are not overwritable anyway
+        statement_to_edit = ConnectivityStatement.objects.filter(
+            Q(state=CSState.EXPORTED) | Q(state=CSState.INVALID)).first()
+
+        if not statement_to_edit:
+            log_error(
+                "No statement found in EXPORTED or INVALID state to test disable_overwrite")
+            return
+
+        statement_to_edit.knowledge_statement = NEW_KNOWLEDGE_STATEMENT
+        statement_to_edit.save()
+
+        # The Knowledge statement will be new updated statement, if the disable_overwrite flag is enabled
+        ingest_statements(disable_overwrite=True)
+        statement_after_edit = ConnectivityStatement.objects.get(
+            id=statement_to_edit.id)
+        self.assertEqual(
+            statement_after_edit.knowledge_statement,
+            NEW_KNOWLEDGE_STATEMENT
+        )
+
+        # The Knowledge statement will be the old statement (from neurondm after ingestion), if the disable_overwrite flag is disabled
+        ingest_statements()
+        statement_after_edit = ConnectivityStatement.objects.get(
+            id=statement_to_edit.id)
+        self.assertNotEqual(
+            statement_after_edit.knowledge_statement,
+            NEW_KNOWLEDGE_STATEMENT
+        )


### PR DESCRIPTION
Fixes https://metacell.atlassian.net/browse/SCKAN-443?focusedCommentId=24192 point b.

- Skips state transition on ingestion if population file is provided
- Updates cli message style to depend on the ingestion result
- Adds new tests to check this new no transition behaviour
- Splits ingestion tests that use mock neurondm from real neurondm