### PR TITLE
SCKAN-449 feat: Add region layer support for custom code relationships

### DIFF
--- a/applications/composer/backend/composer/admin.py
+++ b/applications/composer/backend/composer/admin.py
@@ -144,7 +144,11 @@ class RelationshipAdmin(admin.ModelAdmin):
                 "The code must define a <code>result</code> variable with the output:<br>"
                 "• For TRIPLE relationships: list of dicts [{'name': str, 'uri': str}, ...]<br>"
                 "• For TEXT relationships: list of strings or single string<br>"
-                "• For ANATOMICAL_ENTITY relationships: list of URIs (strings)<br><br>"
+                "• For ANATOMICAL_ENTITY relationships:<br>"
+                "&nbsp;&nbsp;- Simple entities: list of URI strings ['http://purl.obolibrary.org/obo/UBERON_0001234', ...]<br>"
+                "&nbsp;&nbsp;- Region-layer pairs: list of dicts [{'region': 'region_uri', 'layer': 'layer_uri'}, ...]<br>"
+                "&nbsp;&nbsp;- Mixed: list combining both formats<br>"
+                "&nbsp;&nbsp;- Note: Region-layer pairs respect the 'update_anatomical_entities' flag<br><br>"
                 "Errors are logged to the ingestion anomalies file and the relationship will be skipped."
             )
         return form


### PR DESCRIPTION
Closes https://metacell.atlassian.net/browse/SCKAN-449

- Define a new format that allow us to distinguish between simple entities `(string: 'ontology.uri')` and region layer `(dict: {'region': 'region.ontologi.uri', 'layer': layer.ontology.uri'}` pairs in the custom code result variable.  
- Updates the admin page help text for anatomical entity relationships to clearly explain the new format.
- Adapts the process_anatomical_relationship to respect the new format and also the global update_anatomical_entities flag.
- Add a new set of tests to `test_ingest_statements.py` to make sure the new region layer feature works. And also to test the update_anatomical_entities conversion there.

New format that allows both simple and region-layer anatomical entities:
<img width="1276" height="752" alt="image" src="https://github.com/user-attachments/assets/0da4148a-d5fb-4e27-9861-1347ed005c3c" />

After ingestion:
<img width="685" height="103" alt="image" src="https://github.com/user-attachments/assets/db1b9698-d289-4d99-b4bd-3bdbe603a318" />


The new feature respects the update_anatomical_entities flag. 
When layer and region are swapped:
<img width="1236" height="752" alt="image" src="https://github.com/user-attachments/assets/bbd8bcfb-600b-4c38-81c0-8968ae8bd5cf" />

Without the update_anatomical_entities we get an anomaly logged:
> warning,http://uri.interlex.org/tgbugs/uris/readable/sparc-nlp/liver/132,22,"[CUSTOM_RELATIONSHIP] Anatomical entity not found: Required Layer or Region not found. in relationship 'Layer Region' | Details: {'item': ""{'region': 'http://purl.obolibrary.org/obo/UBERON_0035965', 'layer': 'http://uri.interlex.org/base/ilx_0793663'}"", 'relationship_title': 'Layer Region', 'error': 'Required Layer or Region not found.'}"

When the update_anatomical_entities is set:
<img width="623" height="156" alt="image" src="https://github.com/user-attachments/assets/606d47c0-9f02-4b0f-ac3f-5d8f2bb05743" />


